### PR TITLE
[Feature/NiFiCluster] Add max event driven thread count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- [PR #17](https://github.com/konpyutaika/nifikop/pull/17) - **[Operator/NiFiCluster]** Add ability to set max event driven thread count to NiFi Cluster.
 - [PR #6](https://github.com/konpyutaika/nifikop/pull/6) - **[Operator/NiFiCluster]** Add ability to attach additional volumes & volumeMounts to NiFi container.
 
 ### Changed

--- a/api/v1alpha1/nificluster_types.go
+++ b/api/v1alpha1/nificluster_types.go
@@ -145,6 +145,8 @@ type Node struct {
 type ReadOnlyConfig struct {
 	// MaximumTimerDrivenThreadCount define the maximum number of threads for timer driven processors available to the system.
 	MaximumTimerDrivenThreadCount *int32 `json:"maximumTimerDrivenThreadCount,omitempty"`
+	// MaximumEventDrivenThreadCount define the maximum number of threads for event driven processors available to the system.
+	MaximumEventDrivenThreadCount *int32 `json:"maximumEventDrivenThreadCount,omitempty"`
 	// AdditionalSharedEnvs define a set of additional env variables that will shared between all init containers and
 	// containers in the pod.
 	AdditionalSharedEnvs []corev1.EnvVar `json:"additionalSharedEnvs,omitempty"`
@@ -548,6 +550,13 @@ func (nReadOnlyConfig *ReadOnlyConfig) GetMaximumTimerDrivenThreadCount() int32 
 		return 10
 	}
 	return *nReadOnlyConfig.MaximumTimerDrivenThreadCount
+}
+
+func (nReadOnlyConfig *ReadOnlyConfig) GetMaximumEventDrivenThreadCount() int32 {
+	if nReadOnlyConfig.MaximumEventDrivenThreadCount == nil {
+		return 1
+	}
+	return *nReadOnlyConfig.MaximumEventDrivenThreadCount
 }
 
 func (nTaskSpec *NifiClusterTaskSpec) GetDurationMinutes() float64 {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1297,6 +1297,11 @@ func (in *ReadOnlyConfig) DeepCopyInto(out *ReadOnlyConfig) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.MaximumEventDrivenThreadCount != nil {
+		in, out := &in.MaximumEventDrivenThreadCount, &out.MaximumEventDrivenThreadCount
+		*out = new(int32)
+		**out = **in
+	}
 	if in.AdditionalSharedEnvs != nil {
 		in, out := &in.AdditionalSharedEnvs, &out.AdditionalSharedEnvs
 		*out = make([]v1.EnvVar, len(*in))

--- a/config/crd/bases/nifi.konpyutaika.com_nificlusters.yaml
+++ b/config/crd/bases/nifi.konpyutaika.com_nificlusters.yaml
@@ -5868,6 +5868,12 @@ spec:
                               - name
                               type: object
                           type: object
+                        maximumEventDrivenThreadCount:
+                          description: MaximumEventDrivenThreadCount define the maximum
+                            number of threads for event driven processors available
+                            to the system.
+                          format: int32
+                          type: integer
                         maximumTimerDrivenThreadCount:
                           description: MaximumTimerDrivenThreadCount define the maximum
                             number of threads for timer driven processors available
@@ -6279,6 +6285,12 @@ spec:
                         - name
                         type: object
                     type: object
+                  maximumEventDrivenThreadCount:
+                    description: MaximumEventDrivenThreadCount define the maximum
+                      number of threads for event driven processors available to the
+                      system.
+                    format: int32
+                    type: integer
                   maximumTimerDrivenThreadCount:
                     description: MaximumTimerDrivenThreadCount define the maximum
                       number of threads for timer driven processors available to the

--- a/helm/nifikop/crds/nifi.konpyutaika.com_nificlusters.yaml
+++ b/helm/nifikop/crds/nifi.konpyutaika.com_nificlusters.yaml
@@ -5868,6 +5868,12 @@ spec:
                               - name
                               type: object
                           type: object
+                        maximumEventDrivenThreadCount:
+                          description: MaximumEventDrivenThreadCount define the maximum
+                            number of threads for event driven processors available
+                            to the system.
+                          format: int32
+                          type: integer
                         maximumTimerDrivenThreadCount:
                           description: MaximumTimerDrivenThreadCount define the maximum
                             number of threads for timer driven processors available
@@ -6279,6 +6285,12 @@ spec:
                         - name
                         type: object
                     type: object
+                  maximumEventDrivenThreadCount:
+                    description: MaximumEventDrivenThreadCount define the maximum
+                      number of threads for event driven processors available to the
+                      system.
+                    format: int32
+                    type: integer
                   maximumTimerDrivenThreadCount:
                     description: MaximumTimerDrivenThreadCount define the maximum
                       number of threads for timer driven processors available to the

--- a/pkg/clientwrappers/controllersettings/controllersettings.go
+++ b/pkg/clientwrappers/controllersettings/controllersettings.go
@@ -1,18 +1,19 @@
 package controllersettings
 
 import (
+	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
 	"github.com/konpyutaika/nifikop/api/v1alpha1"
 	"github.com/konpyutaika/nifikop/pkg/clientwrappers"
 	"github.com/konpyutaika/nifikop/pkg/common"
 	"github.com/konpyutaika/nifikop/pkg/util/clientconfig"
-	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 var log = ctrl.Log.WithName("controllersettings-method")
 
 func controllerConfigIsSync(cluster *v1alpha1.NifiCluster, entity *nigoapi.ControllerConfigurationEntity) bool {
-	return cluster.Spec.ReadOnlyConfig.GetMaximumTimerDrivenThreadCount() == entity.Component.MaxTimerDrivenThreadCount
+	return cluster.Spec.ReadOnlyConfig.GetMaximumTimerDrivenThreadCount() == entity.Component.MaxTimerDrivenThreadCount &&
+		cluster.Spec.ReadOnlyConfig.GetMaximumEventDrivenThreadCount() == entity.Component.MaxEventDrivenThreadCount
 }
 
 func SyncConfiguration(config *clientconfig.NifiConfig, cluster *v1alpha1.NifiCluster) error {
@@ -50,4 +51,5 @@ func updateControllerConfigEntity(cluster *v1alpha1.NifiCluster, entity *nigoapi
 		entity.Component = &nigoapi.ControllerConfigurationDto{}
 	}
 	entity.Component.MaxTimerDrivenThreadCount = cluster.Spec.ReadOnlyConfig.GetMaximumTimerDrivenThreadCount()
+	entity.Component.MaxEventDrivenThreadCount = cluster.Spec.ReadOnlyConfig.GetMaximumEventDrivenThreadCount()
 }

--- a/site/docs/5_references/1_nifi_cluster/2_read_only_config.md
+++ b/site/docs/5_references/1_nifi_cluster/2_read_only_config.md
@@ -10,6 +10,8 @@ ReadOnlyConfig object specifies the read-only type Nifi config cluster wide, all
 readOnlyConfig:
   # MaximumTimerDrivenThreadCount define the maximum number of threads for timer driven processors available to the system.
   maximumTimerDrivenThreadCount: 30
+  # MaximumEventDrivenThreadCount define the maximum number of threads for event driven processors available to the system.
+  maximumEventDrivenThreadCount: 10
   # Logback configuration that will be applied to the node
   logbackConfig:
     # logback.xml configuration that will replace the one produced based on template
@@ -123,7 +125,8 @@ readOnlyConfig:
 
 |Field|Type|Description|Required|Default|
 |-----|----|-----------|--------|--------|
-|maximumTimerDrivenThreadCount|int32|define the maximum number of threads for timer driven processors available to the system.|No|nil|
+|maximumTimerDrivenThreadCount|int32|define the maximum number of threads for timer driven processors available to the system.|No|10|
+|maximumEventDrivenThreadCount|int32|define the maximum number of threads for event driven processors available to the system.|No|1|
 |additionalSharedEnvs|\[ \][corev1.EnvVar](https://pkg.go.dev/k8s.io/api/core/v1#EnvVar)|define a set of additional env variables that will shared between all init containers and ontainers in the pod..|No|\[ \]|
 |nifiProperties|[NifiProperties](#nifiproperties)|nifi.properties configuration that will be applied to the node.|No|nil|
 |zookeeperProperties|[ZookeeperProperties](#zookeeperproperties)|zookeeper.properties configuration that will be applied to the node.|No|nil|


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | https://github.com/Orange-OpenSource/nifikop/pull/184
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Adds ability to set the `maximumEventDrivenThreadCount` like you can currently set the `maximumTimerDrivenThreadCount`

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Currently, you can only configure it via the UI which isn't ideal when you have flows deployed via nifikop & registry.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes