### PR TITLE
[Feature/Helm] Add support --namespace helm arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- [PR #19](https://github.com/konpyutaika/nifikop/pull/19) - **[Helm chart]** Support --namespace helm arg
 - [PR #18](https://github.com/konpyutaika/nifikop/pull/18) - **[Operator/NiFiCluster]** Support `topologySpreadConstraint`
 - [PR #17](https://github.com/konpyutaika/nifikop/pull/17) - **[Operator/NiFiCluster]** Add ability to set max event driven thread count to NiFi Cluster.
 - [PR #6](https://github.com/konpyutaika/nifikop/pull/6) - **[Operator/NiFiCluster]** Add ability to attach additional volumes & volumeMounts to NiFi container.

--- a/helm/nifikop/templates/deployment.yaml
+++ b/helm/nifikop/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "nifikop.fullname" . }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     app: {{ template "nifikop.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/helm/nifikop/templates/role_binding.yaml
+++ b/helm/nifikop/templates/role_binding.yaml
@@ -11,11 +11,11 @@ metadata:
     heritage: {{ $.Release.Service }}
     release: {{ $.Release.Name }}
   name: {{ template "nifikop.name" $ }}
-  namespace: {{$namespace}}
+  namespace: {{ $namespace }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "nifikop.name" $ }}
-  namespace: {{$.Release.Namespace}}
+  namespace: {{ $.Release.Namespace }}
 roleRef:
   kind: Role
   name: {{ template "nifikop.name" $ }}

--- a/helm/nifikop/templates/service.yaml
+++ b/helm/nifikop/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "nifikop.name" . }}-metrics
+  namespace: {{ $.Release.Namespace }}
   labels:
     component: app
     app: {{ template "nifikop.name" . }}-metrics

--- a/helm/nifikop/templates/service_account.yaml
+++ b/helm/nifikop/templates/service_account.yaml
@@ -12,4 +12,5 @@ metadata:
   {{- else }}
   name: {{ template "nifikop.name" . }}
   {{- end }}
+  namespace: {{ $.Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/Orange-OpenSource/nifikop/pull/182
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Adds support for `--namespace` helm argument to specify which ns to create objects in.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
When installing this chart, it would be nice to be able to specify `--namespace somens` and have the objects put in the right namespace instead of always relying on the kube client being pointing at the correct ns.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes