### PR TITLE
Support user provided issuerRef Group propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- [PR #21](https://github.com/konpyutaika/nifikop/pull/21) - **[Operator]** Propagate user provided issuerRef Group for custom CertManager Issuer.
 - [PR #19](https://github.com/konpyutaika/nifikop/pull/19) - **[Helm chart]** Support --namespace helm arg
 - [PR #18](https://github.com/konpyutaika/nifikop/pull/18) - **[Operator/NiFiCluster]** Support `topologySpreadConstraint`
 - [PR #17](https://github.com/konpyutaika/nifikop/pull/17) - **[Operator/NiFiCluster]** Add ability to set max event driven thread count to NiFi Cluster.

--- a/site/docs/5_references/1_nifi_cluster/6_listeners_config.md
+++ b/site/docs/5_references/1_nifi_cluster/6_listeners_config.md
@@ -51,6 +51,6 @@ Field|Type|Description|Required|Default|
 |tlsSecretName|string| should contain all ssl certs required by nifi including: caCert, caKey, clientCert, clientKey serverCert, serverKey, peerCert, peerKey. | Yes | - |
 |create|boolean| tells the installed cert manager to create the required certs keys. | Yes | - |
 |clusterScoped|boolean| defines if the Issuer created is cluster or namespace scoped. | Yes | - |
-|issuerRef|[ObjectReference](https://docs.cert-manager.io/en/release-0.9/reference/api-docs/index.html#objectreference-v1alpha1)| cIssuerRef allow to use an existing issuer to act as CA: https://cert-manager.io/docs/concepts/issuer/ | No | - |
+|issuerRef|[ObjectReference](https://docs.cert-manager.io/en/release-0.9/reference/api-docs/index.html#objectreference-v1alpha1)| IssuerRef allow to use an existing issuer to act as CA: https://cert-manager.io/docs/concepts/issuer/ | No | - |
 |pkiBackend|enum{"cert-manager"}| | Yes | - |
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/Orange-OpenSource/nifikop/pull/168
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
`IssuerRef.Group` references are currently not carried forward to the `Certificate` being created for users. If we have provided a custom `IssuerRef` under a non-default cert-manager group to create certs for users, it's ignoring the group and so certs are not provisioned correctly. This PR just carries forward the `Group` configured.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Custom `Issuers` or `ClusterIssuers` with a non-default cert-manager `Group` will not work with nifikop. This PR fixes that.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
