### PR TITLE
Remove serviceAnnotations mentions and fix docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixed Bugs
 
 - [PR #76](https://github.com/konpyutaika/nifikop/pull/88) - **[Operator/NiFiCluster]** Re-ordering config out of sync steps.
+- [PR #93](https://github.com/konpyutaika/nifikop/pull/93) - **[Documentation]** Remove serviceAnnotations mentions and fix docs.
 
 
 ## v0.10.0

--- a/config/samples/simplenificluster.yaml
+++ b/config/samples/simplenificluster.yaml
@@ -68,13 +68,19 @@ spec:
         portConfigs:
           - port: 8080
             internalListenerName: "http"
-      serviceAnnotations:
-        toto: tata
+      metadata:
+        annotations:
+          toto: tata
+        labels:
+          titi: tutu
     - name: "nodepart"
       spec:
         type: NodePort
         portConfigs:
           - port: 8080
             internalListenerName: "http"
-      serviceAnnotations:
-        toto: tata
+      metadata:
+        annotations:
+          toto: tata
+        labels:
+          titi: tutu

--- a/site/docs/5_references/1_nifi_cluster/7_external_service_config.md
+++ b/site/docs/5_references/1_nifi_cluster/7_external_service_config.md
@@ -50,5 +50,7 @@ Field|Type|Description|Required|Default|
 
 ## Metadata
 
+Field|Type|Description|Required|Default|
+|-----|----|-----------|--------|--------|
 | annotations | map\[string\]string | Additionnal annotation to merge to the service associated [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set). |No|nil|
 | nodeLabels  | map\[string\]string | Additionnal labels to merge to the service associated [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set).               |No|nil|


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/konpyutaika/nifikop/issues/92
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Removal of `serviceAnnotations` mentions and documentations fixes

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The `serviceAnnotations` field can't be used anymore.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes