### PR TITLE
added pod host aliases for when DNS isn't available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- [PR #114](https://github.com/konpyutaika/nifikop/pull/114) - **[Operator/NifiCluster]** Added ability to set the `PodSpec.HostAliases` to provide Pod-level override of hostname resolution when DNS and other options are not applicable.
+
 ### Changed
 
 ### Deprecated

--- a/api/v1alpha1/nificluster_types.go
+++ b/api/v1alpha1/nificluster_types.go
@@ -129,6 +129,8 @@ type PodPolicy struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 	// Labels specifies additional labels to attach to the pods the operator creates
 	Labels map[string]string `json:"labels,omitempty"`
+	// A list of host aliases to include in every pod's /etc/hosts configuration in the scenario where DNS is not available.
+	HostAliases []corev1.HostAlias `json:"hostAliases,omitempty"`
 }
 
 // rollingUpgradeConfig specifies the rolling upgrade config for the cluster
@@ -298,6 +300,10 @@ type NodeConfig struct {
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 	// podMetadata allows to add additionnal metadata to the node pods
 	PodMetadata Metadata `json:"podMetadata,omitempty"`
+	// A list of host aliases to include in a pod's /etc/hosts configuration in the scenario where DNS is not available.
+	// This list takes precedence of the one at the NifiCluster.Spec.PodPolicy level
+	// +optional
+	HostAliases []corev1.HostAlias `json:"hostAliases,omitempty"`
 	// priorityClassName can be used to set the priority class applied to the node
 	// +optional
 	PriorityClassName *string `json:"priorityClassName,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1229,6 +1229,13 @@ func (in *NodeConfig) DeepCopyInto(out *NodeConfig) {
 		}
 	}
 	in.PodMetadata.DeepCopyInto(&out.PodMetadata)
+	if in.HostAliases != nil {
+		in, out := &in.HostAliases, &out.HostAliases
+		*out = make([]v1.HostAlias, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.PriorityClassName != nil {
 		in, out := &in.PriorityClassName, &out.PriorityClassName
 		*out = new(string)
@@ -1327,6 +1334,13 @@ func (in *PodPolicy) DeepCopyInto(out *PodPolicy) {
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
+		}
+	}
+	if in.HostAliases != nil {
+		in, out := &in.HostAliases, &out.HostAliases
+		*out = make([]v1.HostAlias, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 }

--- a/config/crd/bases/nifi.konpyutaika.com_nificlusters.yaml
+++ b/config/crd/bases/nifi.konpyutaika.com_nificlusters.yaml
@@ -1505,8 +1505,6 @@ spec:
                           by nifi including: caCert, caKey, clientCert, clientKey
                           serverCert, serverKey, peerCert, peerKey'
                         type: string
-                    required:
-                    - tlsSecretName
                     type: object
                   useExternalDNS:
                     description: 'useExternalDNS allow to manage externalDNS usage
@@ -3173,6 +3171,25 @@ spec:
                       format: int64
                       minimum: 1
                       type: integer
+                    hostAliases:
+                      description: A list of host aliases to include in a pod's /etc/hosts
+                        configuration in the scenario where DNS is not available.
+                        This list takes precedence of the one at the NifiCluster.Spec.PodPolicy
+                        level
+                      items:
+                        description: HostAlias holds the mapping between IP and hostnames
+                          that will be injected as an entry in the pod's hosts file.
+                        properties:
+                          hostnames:
+                            description: Hostnames for the above IP address.
+                            items:
+                              type: string
+                            type: array
+                          ip:
+                            description: IP address of the host file entry.
+                            type: string
+                        type: object
+                      type: array
                     image:
                       description: Docker image used by the operator to create the
                         node associated https://hub.docker.com/r/apache/nifi/
@@ -5410,6 +5427,26 @@ spec:
                           format: int64
                           minimum: 1
                           type: integer
+                        hostAliases:
+                          description: A list of host aliases to include in a pod's
+                            /etc/hosts configuration in the scenario where DNS is
+                            not available. This list takes precedence of the one at
+                            the NifiCluster.Spec.PodPolicy level
+                          items:
+                            description: HostAlias holds the mapping between IP and
+                              hostnames that will be injected as an entry in the pod's
+                              hosts file.
+                            properties:
+                              hostnames:
+                                description: Hostnames for the above IP address.
+                                items:
+                                  type: string
+                                type: array
+                              ip:
+                                description: IP address of the host file entry.
+                                type: string
+                            type: object
+                          type: array
                         image:
                           description: Docker image used by the operator to create
                             the node associated https://hub.docker.com/r/apache/nifi/
@@ -6448,6 +6485,23 @@ spec:
                     description: Annotations specifies the annotations to attach to
                       pods the operator creates
                     type: object
+                  hostAliases:
+                    description: A list of host aliases to include in every pod's
+                      /etc/hosts configuration in the scenario where DNS is not available.
+                    items:
+                      description: HostAlias holds the mapping between IP and hostnames
+                        that will be injected as an entry in the pod's hosts file.
+                      properties:
+                        hostnames:
+                          description: Hostnames for the above IP address.
+                          items:
+                            type: string
+                          type: array
+                        ip:
+                          description: IP address of the host file entry.
+                          type: string
+                      type: object
+                    type: array
                   labels:
                     additionalProperties:
                       type: string

--- a/helm/nifikop/crds/nifi.konpyutaika.com_nificlusters.yaml
+++ b/helm/nifikop/crds/nifi.konpyutaika.com_nificlusters.yaml
@@ -1505,8 +1505,6 @@ spec:
                           by nifi including: caCert, caKey, clientCert, clientKey
                           serverCert, serverKey, peerCert, peerKey'
                         type: string
-                    required:
-                    - tlsSecretName
                     type: object
                   useExternalDNS:
                     description: 'useExternalDNS allow to manage externalDNS usage
@@ -3173,6 +3171,25 @@ spec:
                       format: int64
                       minimum: 1
                       type: integer
+                    hostAliases:
+                      description: A list of host aliases to include in a pod's /etc/hosts
+                        configuration in the scenario where DNS is not available.
+                        This list takes precedence of the one at the NifiCluster.Spec.PodPolicy
+                        level
+                      items:
+                        description: HostAlias holds the mapping between IP and hostnames
+                          that will be injected as an entry in the pod's hosts file.
+                        properties:
+                          hostnames:
+                            description: Hostnames for the above IP address.
+                            items:
+                              type: string
+                            type: array
+                          ip:
+                            description: IP address of the host file entry.
+                            type: string
+                        type: object
+                      type: array
                     image:
                       description: Docker image used by the operator to create the
                         node associated https://hub.docker.com/r/apache/nifi/
@@ -5410,6 +5427,26 @@ spec:
                           format: int64
                           minimum: 1
                           type: integer
+                        hostAliases:
+                          description: A list of host aliases to include in a pod's
+                            /etc/hosts configuration in the scenario where DNS is
+                            not available. This list takes precedence of the one at
+                            the NifiCluster.Spec.PodPolicy level
+                          items:
+                            description: HostAlias holds the mapping between IP and
+                              hostnames that will be injected as an entry in the pod's
+                              hosts file.
+                            properties:
+                              hostnames:
+                                description: Hostnames for the above IP address.
+                                items:
+                                  type: string
+                                type: array
+                              ip:
+                                description: IP address of the host file entry.
+                                type: string
+                            type: object
+                          type: array
                         image:
                           description: Docker image used by the operator to create
                             the node associated https://hub.docker.com/r/apache/nifi/
@@ -6448,6 +6485,23 @@ spec:
                     description: Annotations specifies the annotations to attach to
                       pods the operator creates
                     type: object
+                  hostAliases:
+                    description: A list of host aliases to include in every pod's
+                      /etc/hosts configuration in the scenario where DNS is not available.
+                    items:
+                      description: HostAlias holds the mapping between IP and hostnames
+                        that will be injected as an entry in the pod's hosts file.
+                      properties:
+                        hostnames:
+                          description: Hostnames for the above IP address.
+                          items:
+                            type: string
+                          type: array
+                        ip:
+                          description: IP address of the host file entry.
+                          type: string
+                      type: object
+                    type: array
                   labels:
                     additionalProperties:
                       type: string

--- a/helm/nifikop/templates/deployment.yaml
+++ b/helm/nifikop/templates/deployment.yaml
@@ -63,6 +63,12 @@ spec:
       securityContext:
         runAsUser: 1000
       {{- end }}
+      {{- if .Values.hostAliases }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
       containers:
         - command:
             - /manager

--- a/helm/nifikop/values.yaml
+++ b/helm/nifikop/values.yaml
@@ -23,6 +23,10 @@ resources:
     cpu: 1
     memory: 512Mi
 
+## pod spec host aliases for the operator
+## Ref: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
+hostAliases: []
+
 ## If true, create & deploy the CRD
 ##
 createCustomResource: true

--- a/pkg/resources/nifi/pod.go
+++ b/pkg/resources/nifi/pod.go
@@ -123,6 +123,9 @@ func (r *Reconciler) pod(id int32, nodeConfig *v1alpha1.NodeConfig, pvcs []corev
 		{"nodeId": fmt.Sprintf("%d", id)},
 	}
 
+	// merge host aliases together, preferring the aliases in the nodeConfig
+	allHostAliases := util.MergeHostAliases(r.NifiCluster.Spec.Pod.HostAliases, nodeConfig.HostAliases)
+
 	if r.NifiCluster.Spec.GetMetricPort() != nil {
 		anntotationsToMerge = append(anntotationsToMerge, util.MonitoringAnnotations(*r.NifiCluster.Spec.GetMetricPort()))
 	}
@@ -163,6 +166,7 @@ done`,
 			},
 			TopologySpreadConstraints:     r.NifiCluster.Spec.TopologySpreadConstraints,
 			Containers:                    r.injectAdditionalEnvVars(r.generateContainers(nodeConfig, id, podVolumeMounts, zkAddress)),
+			HostAliases:                   allHostAliases,
 			Volumes:                       podVolumes,
 			RestartPolicy:                 corev1.RestartPolicyNever,
 			TerminationGracePeriodSeconds: util.Int64Pointer(120),

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -14,6 +14,7 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/imdario/mergo"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -55,6 +56,25 @@ func MapStringStringPointer(in map[string]string) (out map[string]*string) {
 		out[k] = StringPointer(v)
 	}
 	return
+}
+
+// MergeHostAliases takes two host alias lists and merges them. For IP conflicts, the latter/second list takes precedence
+func MergeHostAliases(globalAliases []corev1.HostAlias, overrideAliases []corev1.HostAlias) []corev1.HostAlias {
+	aliasesMap := map[string]corev1.HostAlias{}
+	aliases := []corev1.HostAlias{}
+
+	for _, alias := range globalAliases {
+		aliasesMap[alias.IP] = alias
+	}
+	// the below will override any existing IPs
+	for _, alias := range overrideAliases {
+		aliasesMap[alias.IP] = alias
+	}
+	for _, alias := range aliasesMap {
+		aliases = append(aliases, alias)
+	}
+
+	return aliases
 }
 
 // MergeLabels merges two given labels

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -61,13 +61,6 @@ func TestMergeHostAliasesJoin(t *testing.T) {
 	if len(results) != 2 {
 		t.Errorf("The merge results are not the correct length: %v+", results)
 	}
-
-	if results[0].IP != "1.2.3.4" {
-		t.Errorf("results are not correct: %v+", results[0])
-	}
-	if results[1].IP != "1.2.3.5" {
-		t.Errorf("results are not correct: %v+", results[0])
-	}
 }
 
 func TestMergeHostAliasesEmpty(t *testing.T) {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,82 @@
+package util
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestMergeHostAliasesOverride(t *testing.T) {
+	globalAliases := []corev1.HostAlias{
+		{
+			IP: "1.2.3.4",
+			Hostnames: []string{
+				"global.host",
+			},
+		},
+	}
+	overrideAliases := []corev1.HostAlias{
+		{
+			IP: "1.2.3.4",
+			Hostnames: []string{
+				"override.host",
+			},
+		},
+	}
+
+	results := MergeHostAliases(globalAliases, overrideAliases)
+
+	if len(results) != 1 {
+		t.Errorf("The merge results are not the correct length: %v+", results)
+	}
+
+	if results[0].IP != "1.2.3.4" {
+		t.Errorf("results are not correct: %v+", results[0])
+	}
+	if len(results[0].Hostnames) != 1 || results[0].Hostnames[0] != "override.host" {
+		t.Errorf("override did not work: %v+", results[0])
+	}
+}
+
+func TestMergeHostAliasesJoin(t *testing.T) {
+	globalAliases := []corev1.HostAlias{
+		{
+			IP: "1.2.3.4",
+			Hostnames: []string{
+				"global.host",
+			},
+		},
+	}
+	overrideAliases := []corev1.HostAlias{
+		{
+			IP: "1.2.3.5",
+			Hostnames: []string{
+				"override.host",
+			},
+		},
+	}
+
+	results := MergeHostAliases(globalAliases, overrideAliases)
+
+	if len(results) != 2 {
+		t.Errorf("The merge results are not the correct length: %v+", results)
+	}
+
+	if results[0].IP != "1.2.3.4" {
+		t.Errorf("results are not correct: %v+", results[0])
+	}
+	if results[1].IP != "1.2.3.5" {
+		t.Errorf("results are not correct: %v+", results[0])
+	}
+}
+
+func TestMergeHostAliasesEmpty(t *testing.T) {
+	globalAliases := []corev1.HostAlias{}
+	overrideAliases := []corev1.HostAlias{}
+
+	results := MergeHostAliases(globalAliases, overrideAliases)
+
+	if len(results) != 0 {
+		t.Errorf("The merge results are not the correct length: %v+", results)
+	}
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This PR adds the ability to set nifi `podSpec.hostAliases` for both the operator and `NifiCluster` pods as documented here: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/

For `NifiCluster` pods, this can be set at both the global level and per-node level. The node-level configs override the global settings.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

In scenarios where DNS isn't available, this provides Pod-level override of hostname resolution when DNS and other options are not applicable. 

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Context: https://konpytika.slack.com/archives/C035X6KP684/p1657221497963029

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
