### PR TITLE
add context to logs, set default log level to info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 - [PR #114](https://github.com/konpyutaika/nifikop/pull/114) - **[Operator/NifiCluster]** Added ability to set the `PodSpec.HostAliases` to provide Pod-level override of hostname resolution when DNS and other options are not applicable.
 
 ### Changed
+
 - [PR #115](https://github.com/konpyutaika/nifikop/pull/115) - **[Operator]** Upgrade go version to 1.18.
+- [PR #121](https://github.com/konpyutaika/nifikop/pull/121) - **[Operator]** Refactor much of the nifikop logging to include more context.
 
 ### Deprecated
 

--- a/controllers/nificlustertask_controller.go
+++ b/controllers/nificlustertask_controller.go
@@ -334,7 +334,7 @@ func (r *NifiClusterTaskReconciler) handlePodRunningTask(nifiCluster *v1alpha1.N
 		if nifiCluster.Status.NodesState[nodeId].GracefulActionState.ActionStep == v1alpha1.RemovePodStatus {
 			actionStep, taskStartTime, err := scale.RemoveClusterNode(clientConfig, nodeId)
 			if err != nil {
-				r.Log.Info("nifi cluster communication error during removing node id",
+				r.Log.Error("nifi cluster communication error during removing node id",
 					zap.String("clusterName", nifiCluster.Name),
 					zap.String("nodeId", nodeId))
 				return errorfactory.New(errorfactory.NifiClusterNotReady{}, err, fmt.Sprintf("node id: %s", nodeId))

--- a/controllers/nifidataflow_controller.go
+++ b/controllers/nifidataflow_controller.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
-	"time"
 
 	"emperror.dev/errors"
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
@@ -90,10 +89,10 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Create it if not exist.
 	if o == nil {
 		if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(instance); err != nil {
-			return RequeueWithError(r.Log, "could not apply last state to annotation", err)
+			return RequeueWithError(r.Log, "could not apply last state to annotation for dataflow "+instance.Name, err)
 		}
 		if err := r.Client.Update(ctx, instance); err != nil {
-			return RequeueWithError(r.Log, "failed to update NifiRegistryClient", err)
+			return RequeueWithError(r.Log, "failed to update NifiDataflow "+instance.Name, err)
 		}
 		o, err = patch.DefaultAnnotator.GetOriginalConfiguration(instance)
 	}
@@ -118,19 +117,19 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 			// This shouldn't trigger anymore, but leaving it here as a safetybelt
 			if k8sutil.IsMarkedForDeletion(instance.ObjectMeta) {
-				r.Log.Info("Dataflow is already gone, there is nothing we can do")
+				r.Log.Info("Dataflow is already gone, there is nothing we can do",
+					zap.String("dataflow", instance.Name))
 				if err = r.removeFinalizer(ctx, instance); err != nil {
-					return RequeueWithError(r.Log, "failed to remove finalizer", err)
+					return RequeueWithError(r.Log, "failed to remove finalizer for dataflow "+instance.Name, err)
 				}
 				return Reconciled()
 			}
 
-			r.Recorder.Event(instance, corev1.EventTypeWarning, "ReferenceRegistryClientError",
-				fmt.Sprintf("Failed to lookup reference registry client : %s in %s",
-					current.Spec.RegistryClientRef.Name, registryClientNamespace))
+			msg := fmt.Sprintf("Failed to lookup reference registry client for dataflow %s : %s in %s",
+				instance.Name, current.Spec.RegistryClientRef.Name, registryClientNamespace)
+			r.Recorder.Event(instance, corev1.EventTypeWarning, "ReferenceRegistryClientError", msg)
 
-			// the cluster does not exist - should have been caught pre-flight
-			return RequeueWithError(r.Log, "failed to lookup referenced registry client", err)
+			return RequeueWithError(r.Log, msg, err)
 		}
 	}
 
@@ -145,19 +144,20 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 			// This shouldn't trigger anymore, but leaving it here as a safetybelt
 			if k8sutil.IsMarkedForDeletion(instance.ObjectMeta) {
-				r.Log.Info("Dataflow context is already gone, there is nothing we can do")
+				r.Log.Info("Dataflow context is already gone, there is nothing we can do",
+					zap.String("dataflow", instance.Name))
 				if err = r.removeFinalizer(ctx, instance); err != nil {
-					return RequeueWithError(r.Log, "failed to remove finalizer", err)
+					return RequeueWithError(r.Log, "failed to remove finalizer for dataflow "+instance.Name, err)
 				}
 				return Reconciled()
 			}
 
-			r.Recorder.Event(instance, corev1.EventTypeWarning, "ReferenceParameterContextError",
-				fmt.Sprintf("Failed to lookup reference parameter-context : %s in %s",
-					instance.Spec.ClusterRef.Name, parameterContextNamespace))
+			msg := fmt.Sprintf("Failed to lookup reference parameter-context for dataflow %s : %s in %s",
+				instance.Name, instance.Spec.ClusterRef.Name, parameterContextNamespace)
+			r.Recorder.Event(instance, corev1.EventTypeWarning, "ReferenceParameterContextError", msg)
 
 			// the cluster does not exist - should have been caught pre-flight
-			return RequeueWithError(r.Log, "failed to lookup referenced parameter-contest", err)
+			return RequeueWithError(r.Log, msg, err)
 		}
 	}
 
@@ -179,15 +179,11 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	clusterRefs = append(clusterRefs, currentClusterRef)
 
 	if !v1alpha1.ClusterRefsEquals(clusterRefs) {
+		msg := fmt.Sprintf("Failed to lookup reference cluster for dataflow %s : %s in %s",
+			instance.Name, instance.Spec.ClusterRef.Name, currentClusterRef.Namespace)
+		r.Recorder.Event(instance, corev1.EventTypeWarning, "ReferenceClusterError", msg)
 
-		r.Recorder.Event(instance, corev1.EventTypeWarning, "ReferenceClusterError",
-			fmt.Sprintf("Failed to lookup reference cluster : %s in %s",
-				instance.Spec.ClusterRef.Name, currentClusterRef.Namespace))
-
-		return RequeueWithError(
-			r.Log,
-			"failed to lookup referenced cluster, due to inconsistency",
-			errors.New("inconsistent cluster references"))
+		return RequeueWithError(r.Log, msg, errors.New("inconsistent cluster references"))
 	}
 
 	// Prepare cluster connection configurations
@@ -203,9 +199,11 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if clusterConnect, err = configManager.BuildConnect(); err != nil {
 		// This shouldn't trigger anymore, but leaving it here as a safetybelt
 		if k8sutil.IsMarkedForDeletion(instance.ObjectMeta) {
-			r.Log.Info("Cluster is already gone, there is nothing we can do")
+			r.Log.Info("Cluster is already gone, there is nothing we can do",
+				zap.String("clusterName", clusterRef.Name),
+				zap.String("dataflow", instance.Name))
 			if err = r.removeFinalizer(ctx, instance); err != nil {
-				return RequeueWithError(r.Log, "failed to remove finalizer", err)
+				return RequeueWithError(r.Log, "failed to remove finalizer for dataflow "+instance.Name, err)
 			}
 			return Reconciled()
 		}
@@ -213,27 +211,26 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		// If the referenced cluster no more exist, just skip the deletion requirement in cluster ref change case.
 		if !v1alpha1.ClusterRefsEquals([]v1alpha1.ClusterReference{instance.Spec.ClusterRef, current.Spec.ClusterRef}) {
 			if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(current); err != nil {
-				return RequeueWithError(r.Log, "could not apply last state to annotation", err)
+				return RequeueWithError(r.Log, "could not apply last state to annotation for dataflow "+instance.Name, err)
 			}
 			if err := r.Client.Update(ctx, current); err != nil {
-				return RequeueWithError(r.Log, "failed to update NifiDataflow", err)
+				return RequeueWithError(r.Log, "failed to update NifiDataflow with updated NifiCluster reference "+instance.Name, err)
 			}
-			return RequeueAfter(time.Duration(15) * time.Second)
+			return RequeueAfter(interval)
 		}
-		r.Recorder.Event(instance, corev1.EventTypeWarning, "ReferenceClusterError",
-			fmt.Sprintf("Failed to lookup reference cluster : %s in %s",
-				instance.Spec.ClusterRef.Name, currentClusterRef.Namespace))
+		msg := fmt.Sprintf("Failed to lookup reference cluster for dataflow %s : %s in %s",
+			instance.Name, instance.Spec.ClusterRef.Name, currentClusterRef.Namespace)
+		r.Recorder.Event(instance, corev1.EventTypeWarning, "ReferenceClusterError", msg)
 
-		// the cluster does not exist - should have been caught pre-flight
-		return RequeueWithError(r.Log, "failed to lookup referenced cluster", err)
+		return RequeueWithError(r.Log, msg, err)
 	}
 
 	// Generate the client configuration.
 	clientConfig, err = configManager.BuildConfig()
 	if err != nil {
-		r.Recorder.Event(instance, corev1.EventTypeWarning, "ReferenceClusterError",
-			fmt.Sprintf("Failed to create HTTP client for the referenced cluster : %s in %s",
-				instance.Spec.ClusterRef.Name, currentClusterRef.Namespace))
+		msg := fmt.Sprintf("Failed to create HTTP client for the referenced cluster for dataflow %s : %s in %s",
+			instance.Name, instance.Spec.ClusterRef.Name, currentClusterRef.Namespace)
+		r.Recorder.Event(instance, corev1.EventTypeWarning, "ReferenceClusterError", msg)
 		// the cluster is gone, so just remove the finalizer
 		if k8sutil.IsMarkedForDeletion(instance.ObjectMeta) {
 			if err = r.removeFinalizer(ctx, instance); err != nil {
@@ -252,12 +249,13 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Ensure the cluster is ready to receive actions
 	if !clusterConnect.IsReady(r.Log) {
-		r.Log.Info("Cluster is not ready yet, will wait until it is.")
+		r.Log.Debug("Cluster is not ready yet, will wait until it is.",
+			zap.String("clusterName", instance.Spec.ClusterRef.Name),
+			zap.String("dataflow", instance.Name))
 		r.Recorder.Event(instance, corev1.EventTypeNormal, "ReferenceClusterNotReady",
-			fmt.Sprintf("The referenced cluster is not ready yet : %s in %s",
-				instance.Spec.ClusterRef.Name, clusterConnect.Id()))
+			fmt.Sprintf("The referenced cluster is not ready yet for dataflow %s : %s in %s",
+				instance.Name, instance.Spec.ClusterRef.Name, clusterConnect.Id()))
 
-		// the cluster does not exist - should have been caught pre-flight
 		return RequeueAfter(interval)
 	}
 
@@ -265,17 +263,17 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if !v1alpha1.ClusterRefsEquals([]v1alpha1.ClusterReference{instance.Spec.ClusterRef, current.Spec.ClusterRef}) {
 		// Delete the resource on the previous cluster.
 		if _, err := dataflow.RemoveDataflow(instance, clientConfig); err != nil {
-			r.Recorder.Event(instance, corev1.EventTypeWarning, "RemoveError",
-				fmt.Sprintf("Failed to delete NifiDataflow %s from cluster %s before moving in %s",
-					instance.Name, original.Spec.ClusterRef.Name, original.Spec.ClusterRef.Name))
-			return RequeueWithError(r.Log, "Failed to delete NifiDataflow before moving", err)
+			msg := fmt.Sprintf("Failed to delete NifiDataflow %s from cluster %s before moving in %s",
+				instance.Name, original.Spec.ClusterRef.Name, original.Spec.ClusterRef.Name)
+			r.Recorder.Event(instance, corev1.EventTypeWarning, "RemoveError", msg)
+			return RequeueWithError(r.Log, msg, err)
 		}
 		// Update the last view configuration to the current one.
 		if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(current); err != nil {
-			return RequeueWithError(r.Log, "could not apply last state to annotation", err)
+			return RequeueWithError(r.Log, "could not apply last state to annotation for dataflow "+instance.Name, err)
 		}
 		if err := r.Client.Update(ctx, current); err != nil {
-			return RequeueWithError(r.Log, "failed to update NifiDatafllow", err)
+			return RequeueWithError(r.Log, "failed to update NifiDataflow "+instance.Name, err)
 		}
 		return RequeueAfter(interval)
 	}
@@ -309,7 +307,7 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				fmt.Sprintf("Creation failed dataflow %s based on flow {bucketId : %s, flowId: %s, version: %s}",
 					instance.Name, instance.Spec.BucketId,
 					instance.Spec.FlowId, strconv.FormatInt(int64(*instance.Spec.FlowVersion), 10)))
-			return RequeueWithError(r.Log, "failure creating dataflow", err)
+			return RequeueWithError(r.Log, "failure creating dataflow "+instance.Name, err)
 		}
 
 		// Set dataflow status
@@ -317,7 +315,7 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		instance.Status.State = v1alpha1.DataflowStateCreated
 
 		if err := r.Client.Status().Update(ctx, instance); err != nil {
-			return RequeueWithError(r.Log, "failed to update NifiDataflow status", err)
+			return RequeueWithError(r.Log, "failed to update status for NifiDataflow "+instance.Name, err)
 		}
 
 		r.Recorder.Event(instance, corev1.EventTypeNormal, "Created",
@@ -330,13 +328,13 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Ensure finalizer for cleanup on deletion
 	if !util.StringSliceContains(instance.GetFinalizers(), dataflowFinalizer) {
-		r.Log.Info("Adding Finalizer for NifiDataflow")
+		r.Log.Info("Adding Finalizer for NifiDataflow " + instance.Name)
 		instance.SetFinalizers(append(instance.GetFinalizers(), dataflowFinalizer))
 	}
 
 	// Push any changes
 	if instance, err = r.updateAndFetchLatest(ctx, instance); err != nil {
-		return RequeueWithError(r.Log, "failed to update NifiDataflow", err)
+		return RequeueWithError(r.Log, "failed to update NifiDataflow "+instance.Name, err)
 	}
 
 	if instance.Spec.SyncNever() {
@@ -354,7 +352,7 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if status != nil {
 			instance.Status = *status
 			if err := r.Client.Status().Update(ctx, instance); err != nil {
-				return RequeueWithError(r.Log, "failed to update NifiDataflow status", err)
+				return RequeueWithError(r.Log, "failed to update status for  NifiDataflow "+instance.Name, err)
 			}
 		}
 		if err != nil {
@@ -372,13 +370,13 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 					fmt.Sprintf("Syncing dataflow %s based on flow {bucketId : %s, flowId: %s, version: %s} failed",
 						instance.Name, instance.Spec.BucketId,
 						instance.Spec.FlowId, strconv.FormatInt(int64(*instance.Spec.FlowVersion), 10)))
-				return RequeueWithError(r.Log, "failed to sync NiFiDataflow", err)
+				return RequeueWithError(r.Log, "failed to sync NiFiDataflow "+instance.Name, err)
 			}
 		}
 
 		instance.Status.State = v1alpha1.DataflowStateInSync
 		if err := r.Client.Status().Update(ctx, instance); err != nil {
-			return RequeueWithError(r.Log, "failed to update NifiDataflow status", err)
+			return RequeueWithError(r.Log, "failed to update status for NifiDataflow "+instance.Name, err)
 		}
 
 		r.Recorder.Event(instance, corev1.EventTypeNormal, "Synchronized",
@@ -390,13 +388,13 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Check if the flow is out of sync
 	isOutOfSink, err := dataflow.IsOutOfSyncDataflow(instance, clientConfig, registryClient, parameterContext)
 	if err != nil {
-		return RequeueWithError(r.Log, "failed to check NifiDataflow sync", err)
+		return RequeueWithError(r.Log, "failed to check sync for NifiDataflow "+instance.Name, err)
 	}
 
 	if isOutOfSink {
 		instance.Status.State = v1alpha1.DataflowStateOutOfSync
 		if err := r.Client.Status().Update(ctx, instance); err != nil {
-			return RequeueWithError(r.Log, "failed to update NifiDataflow status", err)
+			return RequeueWithError(r.Log, "failed to update status for NifiDataflow "+instance.Name, err)
 		}
 		return Requeue()
 	}
@@ -409,7 +407,7 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 		instance.Status.State = v1alpha1.DataflowStateStarting
 		if err := r.Client.Status().Update(ctx, instance); err != nil {
-			return RequeueWithError(r.Log, "failed to update NifiDataflow status", err)
+			return RequeueWithError(r.Log, "failed to update status for NifiDataflow "+instance.Name, err)
 		}
 
 		r.Recorder.Event(instance, corev1.EventTypeNormal, "Starting",
@@ -426,13 +424,13 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 					fmt.Sprintf("Starting dataflow %s based on flow {bucketId : %s, flowId: %s, version: %s} failed.",
 						instance.Name, instance.Spec.BucketId,
 						instance.Spec.FlowId, strconv.FormatInt(int64(*instance.Spec.FlowVersion), 10)))
-				return RequeueWithError(r.Log, "failed to run NifiDataflow", err)
+				return RequeueWithError(r.Log, "failed to run NifiDataflow "+instance.Name, err)
 			}
 		}
 
 		instance.Status.State = v1alpha1.DataflowStateRan
 		if err := r.Client.Status().Update(ctx, instance); err != nil {
-			return RequeueWithError(r.Log, "failed to update NifiDataflow status", err)
+			return RequeueWithError(r.Log, "failed to update status for NifiDataflow "+instance.Name, err)
 		}
 
 		r.Recorder.Event(instance, corev1.EventTypeNormal, "Ran",
@@ -443,12 +441,12 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Ensure NifiCluster label
 	if instance, err = r.ensureClusterLabel(ctx, clusterConnect, instance); err != nil {
-		return RequeueWithError(r.Log, "failed to ensure NifiCluster label on dataflow", err)
+		return RequeueWithError(r.Log, "failed to ensure NifiCluster label on dataflow "+instance.Name, err)
 	}
 
 	// Push any changes
 	if instance, err = r.updateAndFetchLatest(ctx, instance); err != nil {
-		return RequeueWithError(r.Log, "failed to update NifiDataflow", err)
+		return RequeueWithError(r.Log, "failed to update NifiDataflow "+instance.Name, err)
 	}
 
 	r.Log.Info("Ensured Dataflow")
@@ -497,7 +495,8 @@ func (r *NifiDataflowReconciler) updateAndFetchLatest(ctx context.Context,
 
 func (r *NifiDataflowReconciler) checkFinalizers(ctx context.Context, flow *v1alpha1.NifiDataflow,
 	config *clientconfig.NifiConfig) (reconcile.Result, error) {
-	r.Log.Info(fmt.Sprintf("NiFi dataflow %s is marked for deletion", flow.Name))
+	r.Log.Info("NiFi dataflow is marked for deletion",
+		zap.String("dataflow", flow.Name))
 	var err error
 	if util.StringSliceContains(flow.GetFinalizers(), dataflowFinalizer) {
 		if err = r.finalizeNifiDataflow(flow, config); err != nil {
@@ -505,11 +504,11 @@ func (r *NifiDataflowReconciler) checkFinalizers(ctx context.Context, flow *v1al
 			case errorfactory.NifiConnectionDropping, errorfactory.NifiFlowDraining:
 				return RequeueAfter(util.GetRequeueInterval(r.RequeueInterval/3, r.RequeueOffset))
 			default:
-				return RequeueWithError(r.Log, "failed to finalize NiFiDataflow", err)
+				return RequeueWithError(r.Log, "failed to finalize NiFiDataflow "+flow.Name, err)
 			}
 		}
 		if err = r.removeFinalizer(ctx, flow); err != nil {
-			return RequeueWithError(r.Log, "failed to remove finalizer from dataflow", err)
+			return RequeueWithError(r.Log, "failed to remove finalizer from dataflow "+flow.Name, err)
 		}
 	}
 
@@ -517,7 +516,8 @@ func (r *NifiDataflowReconciler) checkFinalizers(ctx context.Context, flow *v1al
 }
 
 func (r *NifiDataflowReconciler) removeFinalizer(ctx context.Context, flow *v1alpha1.NifiDataflow) error {
-	r.Log.Info(fmt.Sprintf("Removing finalizer for NifiDataflow %s", flow.Name))
+	r.Log.Info("Removing finalizer for NifiDataflow",
+		zap.String("dataflow", flow.Name))
 	flow.SetFinalizers(util.StringSliceRemove(flow.GetFinalizers(), dataflowFinalizer))
 	_, err := r.updateAndFetchLatest(ctx, flow)
 	return err
@@ -544,7 +544,8 @@ func (r *NifiDataflowReconciler) finalizeNifiDataflow(flow *v1alpha1.NifiDataflo
 				flow.Name, flow.Spec.BucketId,
 				flow.Spec.FlowId, strconv.FormatInt(int64(*flow.Spec.FlowVersion), 10)))
 
-		r.Log.Info("Dataflow deleted")
+		r.Log.Info("Dataflow deleted",
+			zap.String("dataflow", flow.Name))
 	}
 
 	return nil

--- a/controllers/nifiparametercontext_controller.go
+++ b/controllers/nifiparametercontext_controller.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"time"
 
 	"emperror.dev/errors"
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
@@ -89,10 +88,10 @@ func (r *NifiParameterContextReconciler) Reconcile(ctx context.Context, req ctrl
 	// Create it if not exist.
 	if o == nil {
 		if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(instance); err != nil {
-			return RequeueWithError(r.Log, "could not apply last state to annotation", err)
+			return RequeueWithError(r.Log, "could not apply last state to annotation for parameter context "+instance.Name, err)
 		}
 		if err := r.Client.Update(ctx, instance); err != nil {
-			return RequeueWithError(r.Log, "failed to update NifiParameterContext", err)
+			return RequeueWithError(r.Log, "failed to update NifiParameterContext "+instance.Name, err)
 		}
 		o, err = patch.DefaultAnnotator.GetOriginalConfiguration(instance)
 	}
@@ -113,15 +112,18 @@ func (r *NifiParameterContextReconciler) Reconcile(ctx context.Context, req ctrl
 		if secret, err = k8sutil.LookupSecret(r.Client, parameterSecret.Name, secretNamespace); err != nil {
 			// This shouldn't trigger anymore, but leaving it here as a safetybelt
 			if k8sutil.IsMarkedForDeletion(instance.ObjectMeta) {
-				r.Log.Info("Secret is already gone, there is nothing we can do")
+				r.Log.Error("Secret for parameter context is already gone, there is nothing we can do",
+					zap.String("secretName", parameterSecret.Name),
+					zap.String("secretNamespace", parameterSecret.Namespace),
+					zap.String("parameterContext", instance.Name))
 				if err = r.removeFinalizer(ctx, instance); err != nil {
-					return RequeueWithError(r.Log, "failed to remove finalizer", err)
+					return RequeueWithError(r.Log, "failed to remove finalizer for parameter context "+instance.Name, err)
 				}
 				return Reconciled()
 			}
 
 			// the cluster does not exist - should have been caught pre-flight
-			return RequeueWithError(r.Log, "failed to lookup referenced secret", err)
+			return RequeueWithError(r.Log, "failed to lookup referenced secret for parameter context "+instance.Name, err)
 		}
 		parameterSecrets = append(parameterSecrets, secret)
 	}
@@ -139,37 +141,39 @@ func (r *NifiParameterContextReconciler) Reconcile(ctx context.Context, req ctrl
 	if clusterConnect, err = configManager.BuildConnect(); err != nil {
 		// This shouldn't trigger anymore, but leaving it here as a safetybelt
 		if k8sutil.IsMarkedForDeletion(instance.ObjectMeta) {
-			r.Log.Info("Cluster is already gone, there is nothing we can do")
+			r.Log.Error("Cluster is already gone, there is nothing we can do",
+				zap.String("clusterName", clusterRef.Name),
+				zap.String("parameterContext", instance.Name))
 			if err = r.removeFinalizer(ctx, instance); err != nil {
-				return RequeueWithError(r.Log, "failed to remove finalizer", err)
+				return RequeueWithError(r.Log, "failed to remove finalizer for parameter context "+instance.Name, err)
 			}
 			return Reconciled()
 		}
 		// If the referenced cluster no more exist, just skip the deletion requirement in cluster ref change case.
 		if !v1alpha1.ClusterRefsEquals([]v1alpha1.ClusterReference{instance.Spec.ClusterRef, current.Spec.ClusterRef}) {
 			if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(current); err != nil {
-				return RequeueWithError(r.Log, "could not apply last state to annotation", err)
+				return RequeueWithError(r.Log, "could not apply last state to annotation for parameter context "+instance.Name, err)
 			}
 			if err := r.Client.Update(ctx, current); err != nil {
-				return RequeueWithError(r.Log, "failed to update NifiParameterContext", err)
+				return RequeueWithError(r.Log, "failed to update NifiParameterContext "+instance.Name, err)
 			}
-			return RequeueAfter(time.Duration(15) * time.Second)
+			return RequeueAfter(interval)
 		}
 
-		r.Recorder.Event(instance, corev1.EventTypeWarning, "ReferenceClusterError",
-			fmt.Sprintf("Failed to lookup reference cluster : %s in %s",
-				instance.Spec.ClusterRef.Name, clusterRef.Namespace))
+		msg := fmt.Sprintf("Failed to lookup reference cluster for parameter context %s : %s in %s",
+			instance.Name, instance.Spec.ClusterRef.Name, clusterRef.Namespace)
+		r.Recorder.Event(instance, corev1.EventTypeWarning, "ReferenceClusterError", msg)
 
 		// the cluster does not exist - should have been caught pre-flight
-		return RequeueWithError(r.Log, "failed to lookup referenced cluster", err)
+		return RequeueWithError(r.Log, msg, err)
 	}
 
 	// Generate the client configuration.
 	clientConfig, err = configManager.BuildConfig()
 	if err != nil {
 		r.Recorder.Event(instance, corev1.EventTypeWarning, "ReferenceClusterError",
-			fmt.Sprintf("Failed to create HTTP client for the referenced cluster : %s in %s",
-				instance.Spec.ClusterRef.Name, clusterRef.Namespace))
+			fmt.Sprintf("Failed to create HTTP client for the referenced cluster for parameter context %s : %s in %s",
+				instance.Name, instance.Spec.ClusterRef.Name, clusterRef.Namespace))
 		// the cluster is gone, so just remove the finalizer
 		if k8sutil.IsMarkedForDeletion(instance.ObjectMeta) {
 			if err = r.removeFinalizer(ctx, instance); err != nil {
@@ -188,7 +192,9 @@ func (r *NifiParameterContextReconciler) Reconcile(ctx context.Context, req ctrl
 
 	// Ensure the cluster is ready to receive actions
 	if !clusterConnect.IsReady(r.Log) {
-		r.Log.Info("Cluster is not ready yet, will wait until it is.")
+		r.Log.Debug("Cluster is not ready yet, will wait until it is.",
+			zap.String("clusterName", clusterRef.Name),
+			zap.String("parameterContext", instance.Name))
 		r.Recorder.Event(instance, corev1.EventTypeNormal, "ReferenceClusterNotReady",
 			fmt.Sprintf("The referenced cluster is not ready yet : %s in %s",
 				instance.Spec.ClusterRef.Name, clusterConnect.Id()))
@@ -204,14 +210,14 @@ func (r *NifiParameterContextReconciler) Reconcile(ctx context.Context, req ctrl
 			r.Recorder.Event(instance, corev1.EventTypeWarning, "RemoveError",
 				fmt.Sprintf("Failed to delete NifiParameterContext %s from cluster %s before moving in %s",
 					instance.Name, original.Spec.ClusterRef.Name, original.Spec.ClusterRef.Name))
-			return RequeueWithError(r.Log, "Failed to delete NifiParameterContext before moving", err)
+			return RequeueWithError(r.Log, "Failed to delete NifiParameterContext before moving "+instance.Name, err)
 		}
 		// Update the last view configuration to the current one.
 		if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(current); err != nil {
-			return RequeueWithError(r.Log, "could not apply last state to annotation", err)
+			return RequeueWithError(r.Log, "could not apply last state to annotation for parameter context "+instance.Name, err)
 		}
 		if err := r.Client.Update(ctx, current); err != nil {
-			return RequeueWithError(r.Log, "failed to update NifiParameterContext", err)
+			return RequeueWithError(r.Log, "failed to update NifiParameterContext "+instance.Name, err)
 		}
 		return RequeueAfter(interval)
 	}
@@ -222,7 +228,7 @@ func (r *NifiParameterContextReconciler) Reconcile(ctx context.Context, req ctrl
 	// Check if the NiFi parameter context already exist
 	exist, err := parametercontext.ExistParameterContext(instance, clientConfig)
 	if err != nil {
-		return RequeueWithError(r.Log, "failure checking for existing parameter context", err)
+		return RequeueWithError(r.Log, "failure checking for existing parameter context with name "+instance.Name, err)
 	}
 
 	if !exist {
@@ -234,24 +240,24 @@ func (r *NifiParameterContextReconciler) Reconcile(ctx context.Context, req ctrl
 
 		status, err = parametercontext.FindParameterContextByName(instance, clientConfig)
 		if err != nil {
-			return RequeueWithError(r.Log, "failure finding parameter context", err)
+			return RequeueWithError(r.Log, "failure finding parameter context "+instance.Name, err)
 		}
 
 		if status != nil && !instance.Spec.IsTakeOverEnabled() {
 			// TakeOver disabled
-			return RequeueWithError(r.Log, fmt.Sprintf("parameter context name %s already used and takeOver disabled", instance.GetName()), err)
+			return RequeueWithError(r.Log, fmt.Sprintf("parameter context name %s already used and takeOver disabled", instance.Name), err)
 		}
 		if status == nil {
 			// Create NiFi parameter context
 			status, err = parametercontext.CreateParameterContext(instance, parameterSecrets, clientConfig)
 			if err != nil {
-				return RequeueWithError(r.Log, "failure creating parameter context", err)
+				return RequeueWithError(r.Log, "failure creating parameter context "+instance.Name, err)
 			}
 		}
 
 		instance.Status = *status
 		if err := r.Client.Status().Update(ctx, instance); err != nil {
-			return RequeueWithError(r.Log, "failed to update NifiParameterContext status", err)
+			return RequeueWithError(r.Log, "failed to update status for NifiParameterContext "+instance.Name, err)
 		}
 
 		r.Recorder.Event(instance, corev1.EventTypeNormal, "Created",
@@ -265,7 +271,7 @@ func (r *NifiParameterContextReconciler) Reconcile(ctx context.Context, req ctrl
 	if status != nil {
 		instance.Status = *status
 		if err := r.Client.Status().Update(ctx, instance); err != nil {
-			return RequeueWithError(r.Log, "failed to update NifiParameterContext status", err)
+			return RequeueWithError(r.Log, "failed to update status for NifiParameterContext "+instance.Name, err)
 		}
 	}
 	if err != nil {
@@ -275,7 +281,7 @@ func (r *NifiParameterContextReconciler) Reconcile(ctx context.Context, req ctrl
 		default:
 			r.Recorder.Event(instance, corev1.EventTypeNormal, "SynchronizingFailed",
 				fmt.Sprintf("Synchronizing parameter context %s failed", instance.Name))
-			return RequeueWithError(r.Log, "failed to sync NifiParameterContext", err)
+			return RequeueWithError(r.Log, "failed to sync NifiParameterContext "+instance.Name, err)
 		}
 	}
 
@@ -284,24 +290,26 @@ func (r *NifiParameterContextReconciler) Reconcile(ctx context.Context, req ctrl
 
 	// Ensure NifiCluster label
 	if instance, err = r.ensureClusterLabel(ctx, clusterConnect, instance); err != nil {
-		return RequeueWithError(r.Log, "failed to ensure NifiCluster label on parameter context", err)
+		return RequeueWithError(r.Log, "failed to ensure NifiCluster label on parameter context "+instance.Name, err)
 	}
 
 	// Ensure finalizer for cleanup on deletion
 	if !util.StringSliceContains(instance.GetFinalizers(), parameterContextFinalizer) {
-		r.Log.Info("Adding Finalizer for NifiParameterContext")
+		r.Log.Debug("Adding Finalizer for NifiParameterContext",
+			zap.String("parameterContext", instance.Name))
 		instance.SetFinalizers(append(instance.GetFinalizers(), parameterContextFinalizer))
 	}
 
 	// Push any changes
 	if instance, err = r.updateAndFetchLatest(ctx, instance); err != nil {
-		return RequeueWithError(r.Log, "failed to update NifiParameterContext", err)
+		return RequeueWithError(r.Log, "failed to update NifiParameterContext "+instance.Name, err)
 	}
 
 	r.Recorder.Event(instance, corev1.EventTypeNormal, "Reconciled",
 		fmt.Sprintf("Reconciling parameter context %s", instance.Name))
 
-	r.Log.Info("Ensured Parameter Context")
+	r.Log.Debug("Ensured Parameter Context",
+		zap.String("parameterContext", instance.Name))
 
 	return RequeueAfter(interval)
 }
@@ -341,21 +349,23 @@ func (r *NifiParameterContextReconciler) checkFinalizers(
 	parameterContext *v1alpha1.NifiParameterContext,
 	parameterSecrets []*corev1.Secret,
 	config *clientconfig.NifiConfig) (reconcile.Result, error) {
-	r.Log.Info(fmt.Sprintf("NiFi parameter context %s is marked for deletion", parameterContext.Name))
+	r.Log.Info("NiFi parameter context is marked for deletion. Removing finalizers.",
+		zap.String("parameterContext", parameterContext.Name))
 	var err error
 	if util.StringSliceContains(parameterContext.GetFinalizers(), parameterContextFinalizer) {
 		if err = r.finalizeNifiParameterContext(parameterContext, parameterSecrets, config); err != nil {
-			return RequeueWithError(r.Log, "failed to finalize parameter context", err)
+			return RequeueWithError(r.Log, "failed to finalize parameter context "+parameterContext.Name, err)
 		}
 		if err = r.removeFinalizer(ctx, parameterContext); err != nil {
-			return RequeueWithError(r.Log, "failed to remove finalizer from parameter context", err)
+			return RequeueWithError(r.Log, "failed to remove finalizer from parameter context "+parameterContext.Name, err)
 		}
 	}
 	return Reconciled()
 }
 
 func (r *NifiParameterContextReconciler) removeFinalizer(ctx context.Context, paramCtxt *v1alpha1.NifiParameterContext) error {
-	r.Log.Info(fmt.Sprintf("Removing finalizer for NifiParameterContext %s", paramCtxt.Name))
+	r.Log.Debug("Removing finalizer for NifiParameterContext",
+		zap.String("paramaterContext", paramCtxt.Name))
 	paramCtxt.SetFinalizers(util.StringSliceRemove(paramCtxt.GetFinalizers(), parameterContextFinalizer))
 	_, err := r.updateAndFetchLatest(ctx, paramCtxt)
 	return err
@@ -369,7 +379,8 @@ func (r *NifiParameterContextReconciler) finalizeNifiParameterContext(
 	if err := parametercontext.RemoveParameterContext(parameterContext, parameterSecrets, config); err != nil {
 		return err
 	}
-	r.Log.Info("Delete NifiParameter Context")
+	r.Log.Info("Deleted NifiParameter Context",
+		zap.String("parameterContext", parameterContext.Name))
 
 	return nil
 }

--- a/controllers/nifiregistryclient_controller.go
+++ b/controllers/nifiregistryclient_controller.go
@@ -87,10 +87,10 @@ func (r *NifiRegistryClientReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Create it if not exist.
 	if o == nil {
 		if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(instance); err != nil {
-			return RequeueWithError(r.Log, "could not apply last state to annotation", err)
+			return RequeueWithError(r.Log, "could not apply last state to annotation for registry client"+instance.Name, err)
 		}
 		if err := r.Client.Update(ctx, instance); err != nil {
-			return RequeueWithError(r.Log, "failed to update NifiRegistryClient", err)
+			return RequeueWithError(r.Log, "failed to update NifiRegistryClient "+instance.Name, err)
 		}
 		o, err = patch.DefaultAnnotator.GetOriginalConfiguration(instance)
 	}
@@ -116,19 +116,21 @@ func (r *NifiRegistryClientReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if clusterConnect, err = configManager.BuildConnect(); err != nil {
 		// This shouldn't trigger anymore, but leaving it here as a safetybelt
 		if k8sutil.IsMarkedForDeletion(instance.ObjectMeta) {
-			r.Log.Info("Cluster is already gone, there is nothing we can do")
+			r.Log.Error("Cluster is already gone, there is nothing we can do",
+				zap.String("registryClient", instance.Name),
+				zap.String("clusterName", clusterRef.Name))
 			if err = r.removeFinalizer(ctx, instance); err != nil {
-				return RequeueWithError(r.Log, "failed to remove finalizer", err)
+				return RequeueWithError(r.Log, "failed to remove finalizer for registry client "+instance.Name, err)
 			}
 			return Reconciled()
 		}
 		// If the referenced cluster no more exist, just skip the deletion requirement in cluster ref change case.
 		if !v1alpha1.ClusterRefsEquals([]v1alpha1.ClusterReference{instance.Spec.ClusterRef, current.Spec.ClusterRef}) {
 			if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(current); err != nil {
-				return RequeueWithError(r.Log, "could not apply last state to annotation", err)
+				return RequeueWithError(r.Log, "could not apply last state to annotation to registry client "+instance.Name, err)
 			}
 			if err := r.Client.Update(ctx, current); err != nil {
-				return RequeueWithError(r.Log, "failed to update NifiRegistryClient", err)
+				return RequeueWithError(r.Log, "failed to update NifiRegistryClient "+instance.Name, err)
 			}
 			return RequeueAfter(time.Duration(15) * time.Second)
 		}
@@ -137,7 +139,7 @@ func (r *NifiRegistryClientReconciler) Reconcile(ctx context.Context, req ctrl.R
 			fmt.Sprintf("Failed to lookup reference cluster : %s in %s",
 				instance.Spec.ClusterRef.Name, clusterRef.Namespace))
 		// the cluster does not exist - should have been caught pre-flight
-		return RequeueWithError(r.Log, "failed to lookup referenced cluster", err)
+		return RequeueWithError(r.Log, "failed to lookup referenced cluster for registry client "+instance.Name, err)
 	}
 
 	// Generate the client configuration.
@@ -149,22 +151,24 @@ func (r *NifiRegistryClientReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// the cluster is gone, so just remove the finalizer
 		if k8sutil.IsMarkedForDeletion(instance.ObjectMeta) {
 			if err = r.removeFinalizer(ctx, instance); err != nil {
-				return RequeueWithError(r.Log, fmt.Sprintf("failed to remove finalizer from NifiRegistryClient %s", instance.Name), err)
+				return RequeueWithError(r.Log, "failed to remove finalizer from NifiRegistryClient "+instance.Name, err)
 			}
 			return Reconciled()
 		}
 		// the cluster does not exist - should have been caught pre-flight
-		return RequeueWithError(r.Log, "failed to create HTTP client the for referenced cluster", err)
+		return RequeueWithError(r.Log, "failed to create HTTP client the for referenced cluster "+clusterRef.Name+" for registry client "+instance.Name, err)
 	}
 
 	// Check if marked for deletion and if so run finalizers
 	if k8sutil.IsMarkedForDeletion(instance.ObjectMeta) {
-		return r.checkFinalizers(ctx, r.Log, instance, clientConfig)
+		return r.checkFinalizers(ctx, instance, clientConfig)
 	}
 
 	// Ensure the cluster is ready to receive actions
 	if !clusterConnect.IsReady(r.Log) {
-		r.Log.Info("Cluster is not ready yet, will wait until it is.")
+		r.Log.Debug("Cluster is not ready yet, will wait until it is.",
+			zap.String("registryClient", instance.Name),
+			zap.String("clusterName", clusterRef.Name))
 		r.Recorder.Event(instance, corev1.EventTypeNormal, "ReferenceClusterNotReady",
 			fmt.Sprintf("The referenced cluster is not ready yet : %s in %s",
 				instance.Spec.ClusterRef.Name, clusterConnect.Id()))
@@ -183,21 +187,21 @@ func (r *NifiRegistryClientReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 		// Update the last view configuration to the current one.
 		if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(current); err != nil {
-			return RequeueWithError(r.Log, "could not apply last state to annotation", err)
+			return RequeueWithError(r.Log, "could not apply last state to annotation for registry client "+instance.Name, err)
 		}
 		if err := r.Client.Update(ctx, current); err != nil {
-			return RequeueWithError(r.Log, "failed to update NifiRegistryClient", err)
+			return RequeueWithError(r.Log, "failed to update NifiRegistryClient "+instance.Name, err)
 		}
 		return RequeueAfter(interval)
 	}
 
 	r.Recorder.Event(instance, corev1.EventTypeNormal, "Reconciling",
-		fmt.Sprintf("Reconciling registry client %s", instance.Name))
+		"Reconciling registry client "+instance.Name)
 
 	// Check if the NiFi registry client already exist
 	exist, err := registryclient.ExistRegistryClient(instance, clientConfig)
 	if err != nil {
-		return RequeueWithError(r.Log, "failure checking for existing registry client", err)
+		return RequeueWithError(r.Log, "failure checking for existing registry client "+instance.Name, err)
 	}
 
 	if !exist {
@@ -206,22 +210,24 @@ func (r *NifiRegistryClientReconciler) Reconcile(ctx context.Context, req ctrl.R
 			fmt.Sprintf("Creating registry client %s", instance.Name))
 		status, err := registryclient.CreateRegistryClient(instance, clientConfig)
 		if err != nil {
-			return RequeueWithError(r.Log, "failure creating registry client", err)
+			return RequeueWithError(r.Log, "failure creating registry client "+instance.Name, err)
 		}
 
 		instance.Status = *status
 		if err := r.Client.Status().Update(ctx, instance); err != nil {
-			return RequeueWithError(r.Log, "failed to update NifiRegistryClient status", err)
+			return RequeueWithError(r.Log, "failed to update status for NifiRegistryClient "+instance.Name, err)
 		}
 
 		r.Recorder.Event(instance, corev1.EventTypeNormal, "Created",
 			fmt.Sprintf("Created registry client %s", instance.Name))
+		r.Log.Info("Created registry client",
+			zap.String("registryClient", instance.Name))
 
 		if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(instance); err != nil {
-			return RequeueWithError(r.Log, "could not apply last state to annotation", err)
+			return RequeueWithError(r.Log, "could not apply last state to annotation for registry client "+instance.Name, err)
 		}
 		if err := r.Client.Update(ctx, instance); err != nil {
-			return RequeueWithError(r.Log, "failed to update NifiRegistryClient", err)
+			return RequeueWithError(r.Log, "failed to update NifiRegistryClient "+instance.Name, err)
 		}
 	}
 
@@ -232,36 +238,38 @@ func (r *NifiRegistryClientReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if err != nil {
 		r.Recorder.Event(instance, corev1.EventTypeNormal, "SynchronizingFailed",
 			fmt.Sprintf("Synchronizing registry client %s failed", instance.Name))
-		return RequeueWithError(r.Log, "failed to sync NifiRegistryClient", err)
+		return RequeueWithError(r.Log, "failed to sync NifiRegistryClient "+instance.Name, err)
 	}
 
 	instance.Status = *status
 	if err := r.Client.Status().Update(ctx, instance); err != nil {
-		return RequeueWithError(r.Log, "failed to update NifiRegistryClient status", err)
+		return RequeueWithError(r.Log, "failed to update status for NifiRegistryClient "+instance.Name, err)
 	}
 
 	r.Recorder.Event(instance, corev1.EventTypeNormal, "Synchronized",
 		fmt.Sprintf("Synchronized registry client %s", instance.Name))
 	// Ensure NifiCluster label
 	if instance, err = r.ensureClusterLabel(ctx, clusterConnect, instance); err != nil {
-		return RequeueWithError(r.Log, "failed to ensure NifiCluster label on registry client", err)
+		return RequeueWithError(r.Log, "failed to ensure NifiCluster label on registry client "+instance.Name, err)
 	}
 
 	// Ensure finalizer for cleanup on deletion
 	if !util.StringSliceContains(instance.GetFinalizers(), registryClientFinalizer) {
-		r.Log.Info("Adding Finalizer for NifiRegistryClient")
+		r.Log.Debug("Adding Finalizer for NifiRegistryClient",
+			zap.String("registryClient", instance.Name))
 		instance.SetFinalizers(append(instance.GetFinalizers(), registryClientFinalizer))
 	}
 
 	// Push any changes
 	if instance, err = r.updateAndFetchLatest(ctx, instance); err != nil {
-		return RequeueWithError(r.Log, "failed to update NifiRegistryClient", err)
+		return RequeueWithError(r.Log, "failed to update NifiRegistryClient "+instance.Name, err)
 	}
 
 	r.Recorder.Event(instance, corev1.EventTypeNormal, "Reconciled",
 		fmt.Sprintf("Reconciling registry client %s", instance.Name))
 
-	r.Log.Info("Ensured Registry Client")
+	r.Log.Debug("Ensured Registry Client",
+		zap.String("registryClient", instance.Name))
 
 	return RequeueAfter(interval)
 }
@@ -296,35 +304,38 @@ func (r *NifiRegistryClientReconciler) updateAndFetchLatest(ctx context.Context,
 	return registryClient, nil
 }
 
-func (r *NifiRegistryClientReconciler) checkFinalizers(ctx context.Context, reqLogger zap.Logger,
+func (r *NifiRegistryClientReconciler) checkFinalizers(ctx context.Context,
 	registryClient *v1alpha1.NifiRegistryClient, config *clientconfig.NifiConfig) (reconcile.Result, error) {
-	reqLogger.Info(fmt.Sprintf("NiFi registry client %s is marked for deletion", registryClient.Name))
+	r.Log.Info("NiFi registry client is marked for deletion. Removing finalizers.",
+		zap.String("registryClient", registryClient.Name))
 	var err error
 	if util.StringSliceContains(registryClient.GetFinalizers(), registryClientFinalizer) {
-		if err = r.finalizeNifiRegistryClient(reqLogger, registryClient, config); err != nil {
-			return RequeueWithError(reqLogger, "failed to finalize nifiregistryclient", err)
+		if err = r.finalizeNifiRegistryClient(registryClient, config); err != nil {
+			return RequeueWithError(r.Log, "failed to finalize nifiregistryclient", err)
 		}
 		if err = r.removeFinalizer(ctx, registryClient); err != nil {
-			return RequeueWithError(reqLogger, "failed to remove finalizer from nifiregistryclient", err)
+			return RequeueWithError(r.Log, "failed to remove finalizer from nifiregistryclient", err)
 		}
 	}
 	return Reconciled()
 }
 
 func (r *NifiRegistryClientReconciler) removeFinalizer(ctx context.Context, registryClient *v1alpha1.NifiRegistryClient) error {
-	r.Log.Info(fmt.Sprintf("Removing finalizer for NifiRegistryClient %s", registryClient.Name))
+	r.Log.Debug("Removing finalizer for NifiRegistryClient",
+		zap.String("registryClient", registryClient.Name))
 	registryClient.SetFinalizers(util.StringSliceRemove(registryClient.GetFinalizers(), registryClientFinalizer))
 	_, err := r.updateAndFetchLatest(ctx, registryClient)
 	return err
 }
 
-func (r *NifiRegistryClientReconciler) finalizeNifiRegistryClient(reqLogger zap.Logger, registryClient *v1alpha1.NifiRegistryClient,
+func (r *NifiRegistryClientReconciler) finalizeNifiRegistryClient(registryClient *v1alpha1.NifiRegistryClient,
 	config *clientconfig.NifiConfig) error {
 
 	if err := registryclient.RemoveRegistryClient(registryClient, config); err != nil {
 		return err
 	}
-	reqLogger.Info("Delete Registry client")
+	r.Log.Info("Deleted Registry client",
+		zap.String("registryClient", registryClient.Name))
 
 	return nil
 }

--- a/controllers/nifiuser_controller.go
+++ b/controllers/nifiuser_controller.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"time"
 
 	"emperror.dev/errors"
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
@@ -93,10 +92,10 @@ func (r *NifiUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// Create it if not exist.
 	if o == nil {
 		if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(instance); err != nil {
-			return RequeueWithError(r.Log, "could not apply last state to annotation", err)
+			return RequeueWithError(r.Log, "could not apply last state to annotation for nifi user "+instance.Name, err)
 		}
 		if err := r.Client.Update(ctx, instance); err != nil {
-			return RequeueWithError(r.Log, "failed to update NifiUser", err)
+			return RequeueWithError(r.Log, "failed to update NifiUser "+instance.Name, err)
 		}
 		o, err = patch.DefaultAnnotator.GetOriginalConfiguration(instance)
 	}
@@ -122,9 +121,11 @@ func (r *NifiUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if clusterConnect, err = configManager.BuildConnect(); err != nil {
 		// This shouldn't trigger anymore, but leaving it here as a safetybelt
 		if k8sutil.IsMarkedForDeletion(instance.ObjectMeta) {
-			r.Log.Info("Cluster is gone already, there is nothing we can do")
+			r.Log.Error("Cluster is gone already, there is nothing we can do",
+				zap.String("user", instance.Name),
+				zap.String("clusterName", clusterRef.Name))
 			if err = r.removeFinalizer(ctx, instance); err != nil {
-				return RequeueWithError(r.Log, "failed to remove finalizer from NifiUser", err)
+				return RequeueWithError(r.Log, "failed to remove finalizer from NifiUser "+instance.Name, err)
 			}
 			return Reconciled()
 		}
@@ -132,18 +133,18 @@ func (r *NifiUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		// If the referenced cluster no more exist, just skip the deletion requirement in cluster ref change case.
 		if !v1alpha1.ClusterRefsEquals([]v1alpha1.ClusterReference{instance.Spec.ClusterRef, current.Spec.ClusterRef}) {
 			if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(current); err != nil {
-				return RequeueWithError(r.Log, "could not apply last state to annotation", err)
+				return RequeueWithError(r.Log, "could not apply last state to annotation for user "+instance.Name, err)
 			}
 			if err := r.Client.Update(ctx, current); err != nil {
-				return RequeueWithError(r.Log, "failed to update NifiUser", err)
+				return RequeueWithError(r.Log, "failed to update NifiUser "+instance.Name, err)
 			}
-			return RequeueAfter(time.Duration(15) * time.Second)
+			return RequeueAfter(interval)
 		}
 
 		r.Recorder.Event(instance, corev1.EventTypeWarning, "ReferenceClusterError",
 			fmt.Sprintf("Failed to lookup reference cluster : %s in %s",
 				instance.Spec.ClusterRef.Name, clusterRef.Namespace))
-		return RequeueWithError(r.Log, "failed to lookup referenced cluster", err)
+		return RequeueWithError(r.Log, "failed to lookup referenced cluster "+clusterRef.Name+" for user "+instance.Name, err)
 	}
 
 	// Get the referenced NifiCluster
@@ -151,9 +152,11 @@ func (r *NifiUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if cluster, err = k8sutil.LookupNifiCluster(r.Client, instance.Spec.ClusterRef.Name, clusterRef.Namespace); err != nil {
 		// This shouldn't trigger anymore, but leaving it here as a safetybelt
 		if k8sutil.IsMarkedForDeletion(instance.ObjectMeta) {
-			r.Log.Info("Cluster is gone already, there is nothing we can do")
+			r.Log.Error("Cluster is gone already, there is nothing we can do",
+				zap.String("user", instance.Name),
+				zap.String("clusterName", clusterRef.Name))
 			if err = r.removeFinalizer(ctx, instance); err != nil {
-				return RequeueWithError(r.Log, "failed to remove finalizer from NifiUser", err)
+				return RequeueWithError(r.Log, "failed to remove finalizer from NifiUser "+instance.Name, err)
 			}
 			return Reconciled()
 		}
@@ -165,16 +168,17 @@ func (r *NifiUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		// Avoid panic if the user wants to create a nifi user but the cluster is in plaintext mode
 		// TODO: refactor this and use webhook to validate if the cluster is eligible to create a nifi user
 		if cluster.Spec.ListenersConfig.SSLSecrets == nil {
-			return RequeueWithError(r.Log, "could not create Nifi user since cluster does not use ssl", errors.New("failed to create Nifi user"))
+			return RequeueWithError(r.Log, "could not create Nifi user since cluster does not use ssl. user: "+instance.Name, errors.New("failed to create Nifi user"))
 		}
 
 		pkiManager := pki.GetPKIManager(r.Client, cluster)
 
 		// check if marked for deletion
 		if k8sutil.IsMarkedForDeletion(instance.ObjectMeta) {
-			r.Log.Info("Nifi user is marked for deletion, revoking certificates")
+			r.Log.Info("Nifi user is marked for deletion, revoking certificates and removing finalizers.",
+				zap.String("user", instance.Name))
 			if err = pkiManager.FinalizeUserCertificate(ctx, instance); err != nil {
-				return RequeueWithError(r.Log, "failed to finalize user certificate", err)
+				return RequeueWithError(r.Log, "failed to finalize certificate for user "+instance.Name, err)
 			}
 		}
 
@@ -189,7 +193,8 @@ func (r *NifiUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		if err != nil {
 			switch errors.Cause(err).(type) {
 			case errorfactory.ResourceNotReady:
-				r.Log.Info("generated secret not found, may not be ready")
+				r.Log.Debug("generated secret not found, may not be ready",
+					zap.String("user", instance.Name))
 				return ctrl.Result{
 					Requeue:      true,
 					RequeueAfter: interval / 3,
@@ -198,20 +203,24 @@ func (r *NifiUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				// TODO: (tinyzimmer) - Sleep for longer for now to give user time to see the error
 				// But really we should catch these kinds of issues in a pre-admission hook in a future PR
 				// The user can fix while this is looping and it will pick it up next reconcile attempt
-				r.Log.Error("Fatal error attempting to reconcile the user certificate. If using vault perhaps a permissions issue or improperly configured PKI?", zap.Error(err))
+				r.Log.Error("Fatal error attempting to reconcile the user certificate. If using vault perhaps a permissions issue or improperly configured PKI?",
+					zap.String("user", instance.Name),
+					zap.Error(err))
 				return ctrl.Result{
 					Requeue:      true,
 					RequeueAfter: interval,
 				}, nil
 			case errorfactory.VaultAPIFailure:
 				// Same as above in terms of things that could be checked pre-flight on the cluster
-				r.Log.Error("Vault API error attempting to reconcile the user certificate. If using vault perhaps a permissions issue or improperly configured PKI?", zap.Error(err))
+				r.Log.Error("Vault API error attempting to reconcile the user certificate. If using vault perhaps a permissions issue or improperly configured PKI?",
+					zap.String("user", instance.Name),
+					zap.Error(err))
 				return ctrl.Result{
 					Requeue:      true,
 					RequeueAfter: interval,
 				}, nil
 			default:
-				return RequeueWithError(r.Log, "failed to reconcile user secret", err)
+				return RequeueWithError(r.Log, "failed to reconcile secret for user "+instance.Name, err)
 			}
 		}
 
@@ -233,7 +242,7 @@ func (r *NifiUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return Reconciled()
 		}
 		// the cluster does not exist - should have been caught pre-flight
-		return RequeueWithError(r.Log, "failed to create HTTP client the for referenced cluster", err)
+		return RequeueWithError(r.Log, "failed to create HTTP client the for referenced cluster "+clusterRef.Name+" for user "+instance.Name, err)
 	}
 
 	// check if marked for deletion
@@ -243,7 +252,9 @@ func (r *NifiUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	// Ensure the cluster is ready to receive actions
 	if !clusterConnect.IsReady(r.Log) {
-		r.Log.Info("Cluster is not ready yet, will wait until it is.")
+		r.Log.Debug("Cluster is not ready yet, will wait until it is.",
+			zap.String("user", instance.Name),
+			zap.String("clusterName", clusterRef.Name))
 		r.Recorder.Event(instance, corev1.EventTypeNormal, "ReferenceClusterNotReady",
 			fmt.Sprintf("The referenced cluster is not ready yet : %s in %s",
 				instance.Spec.ClusterRef.Name, clusterConnect.Id()))
@@ -256,16 +267,16 @@ func (r *NifiUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		// Delete the resource on the previous cluster.
 		if err := usercli.RemoveUser(instance, clientConfig); err != nil {
 			r.Recorder.Event(instance, corev1.EventTypeWarning, "RemoveError",
-				fmt.Sprintf("Failed to delete NifiUser %s from cluster %s before moving in %s",
-					instance.Name, original.Spec.ClusterRef.Name, original.Spec.ClusterRef.Name))
-			return RequeueWithError(r.Log, "Failed to delete NifiUser before moving", err)
+				fmt.Sprintf("Failed to delete NifiUser %s from cluster %s before moving in namespace %s",
+					instance.Name, original.Spec.ClusterRef.Name, original.Spec.ClusterRef.Namespace))
+			return RequeueWithError(r.Log, "Failed to delete NifiUser before moving into different namespace. user: "+instance.Name, err)
 		}
 		// Update the last view configuration to the current one.
 		if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(current); err != nil {
-			return RequeueWithError(r.Log, "could not apply last state to annotation", err)
+			return RequeueWithError(r.Log, "could not apply last state to annotation for user "+instance.Name, err)
 		}
 		if err := r.Client.Update(ctx, current); err != nil {
-			return RequeueWithError(r.Log, "failed to update NifiUser", err)
+			return RequeueWithError(r.Log, "failed to update NifiUser "+instance.Name, err)
 		}
 		return RequeueAfter(interval)
 	}
@@ -276,7 +287,7 @@ func (r *NifiUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// Check if the NiFi user already exist
 	exist, err := usercli.ExistUser(instance, clientConfig)
 	if err != nil {
-		return RequeueWithError(r.Log, "failure checking for existing registry client", err)
+		return RequeueWithError(r.Log, "failure checking for existing user "+instance.Name, err)
 	}
 
 	if !exist {
@@ -287,20 +298,20 @@ func (r *NifiUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 		status, err = usercli.FindUserByIdentity(instance, clientConfig)
 		if err != nil {
-			return RequeueWithError(r.Log, "failure finding user", err)
+			return RequeueWithError(r.Log, "failure finding user "+instance.Name, err)
 		}
 
 		if status == nil {
 			// Create NiFi registry client
 			status, err = usercli.CreateUser(instance, clientConfig)
 			if err != nil {
-				return RequeueWithError(r.Log, "failure creating user", err)
+				return RequeueWithError(r.Log, "failure creating user "+instance.Name, err)
 			}
 		}
 
 		instance.Status = *status
 		if err := r.Client.Status().Update(ctx, instance); err != nil {
-			return RequeueWithError(r.Log, "failed to update NifiUser status", err)
+			return RequeueWithError(r.Log, "failed to update status for NifiUser "+instance.Name, err)
 		}
 		r.Recorder.Event(instance, corev1.EventTypeNormal, "Created",
 			fmt.Sprintf("Created user %s", instance.Name))
@@ -311,12 +322,12 @@ func (r *NifiUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		fmt.Sprintf("Synchronizing user %s", instance.Name))
 	status, err := usercli.SyncUser(instance, clientConfig)
 	if err != nil {
-		return RequeueWithError(r.Log, "failed to sync NifiUser", err)
+		return RequeueWithError(r.Log, "failed to sync NifiUser "+instance.Name, err)
 	}
 
 	instance.Status = *status
 	if err := r.Client.Status().Update(ctx, instance); err != nil {
-		return RequeueWithError(r.Log, "failed to update NifiUser status", err)
+		return RequeueWithError(r.Log, "failed to update status for NifiUser "+instance.Name, err)
 	}
 
 	r.Recorder.Event(instance, corev1.EventTypeNormal, "Synchronized",
@@ -324,38 +335,29 @@ func (r *NifiUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	// ensure a NifiCluster label
 	if instance, err = r.ensureClusterLabel(ctx, clusterConnect, instance); err != nil {
-		return RequeueWithError(r.Log, "failed to ensure NifiCluster label on user", err)
+		return RequeueWithError(r.Log, "failed to ensure NifiCluster label on user "+instance.Name, err)
 	}
 
 	// ensure a finalizer for cleanup on deletion
 	if !util.StringSliceContains(instance.GetFinalizers(), userFinalizer) {
 		r.addFinalizer(instance)
 		if instance, err = r.updateAndFetchLatest(ctx, instance); err != nil {
-			return RequeueWithError(r.Log, "failed to update NifiUser with finalizer", err)
+			return RequeueWithError(r.Log, "failed to update finalizer for NifiUser "+instance.Name, err)
 		}
 	}
 
 	// Push any changes
 	if instance, err = r.updateAndFetchLatest(ctx, instance); err != nil {
-		return RequeueWithError(r.Log, "failed to update NifiUser", err)
+		return RequeueWithError(r.Log, "failed to update NifiUser "+instance.Name, err)
 	}
 
 	r.Recorder.Event(instance, corev1.EventTypeNormal, "Reconciled",
 		fmt.Sprintf("Reconciling user %s", instance.Name))
 
-	r.Log.Info("Ensured user")
+	r.Log.Debug("Ensured user",
+		zap.String("user", instance.Name))
 
 	return RequeueAfter(interval)
-
-	// set user status
-	//instance.Status = v1alpha1.NifiUserStatus{
-	//	State: v1alpha1.UserStateCreated,
-	//}
-	//if err := r.Client.Status().Update(ctx, instance); err != nil {
-	//	return RequeueWithError(r.Log, "failed to update NifiUser status", err)
-	//}
-
-	//return Reconciled()
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -391,22 +393,24 @@ func (r *NifiUserReconciler) updateAndFetchLatest(ctx context.Context, user *v1a
 }
 
 func (r *NifiUserReconciler) checkFinalizers(ctx context.Context, user *v1alpha1.NifiUser, config *clientconfig.NifiConfig) (reconcile.Result, error) {
-	r.Log.Info(fmt.Sprintf("NiFi user %s is marked for deletion", user.Name))
+	r.Log.Info("NiFi user is marked for deletion. Removing finalizers.",
+		zap.String("user", user.Name))
 	var err error
 	if util.StringSliceContains(user.GetFinalizers(), userFinalizer) {
 		if err = r.finalizeNifiUser(user, config); err != nil {
-			return RequeueWithError(r.Log, "failed to finalize nifiuser", err)
+			return RequeueWithError(r.Log, "failed to finalize nifiuser "+user.Name, err)
 		}
 		// remove finalizer
 		if err = r.removeFinalizer(ctx, user); err != nil {
-			return RequeueWithError(r.Log, "failed to remove finalizer from NifiUser", err)
+			return RequeueWithError(r.Log, "failed to remove finalizer from NifiUser "+user.Name, err)
 		}
 	}
 	return Reconciled()
 }
 
 func (r *NifiUserReconciler) removeFinalizer(ctx context.Context, user *v1alpha1.NifiUser) error {
-	r.Log.Info(fmt.Sprintf("Removing finalizer for NifiUser %s", user.Name))
+	r.Log.Debug("Removing finalizer for NifiUser",
+		zap.String("user", user.Name))
 	user.SetFinalizers(util.StringSliceRemove(user.GetFinalizers(), userFinalizer))
 	_, err := r.updateAndFetchLatest(ctx, user)
 	return err
@@ -416,12 +420,14 @@ func (r *NifiUserReconciler) finalizeNifiUser(user *v1alpha1.NifiUser, config *c
 	if err := usercli.RemoveUser(user, config); err != nil {
 		return err
 	}
-	r.Log.Info(fmt.Sprintf("Deleted user %s", user.Name))
+	r.Log.Info("Deleted user",
+		zap.String("user", user.Name))
 	return nil
 }
 
 func (r *NifiUserReconciler) addFinalizer(user *v1alpha1.NifiUser) {
-	r.Log.Info(fmt.Sprintf("Adding Finalizer for the NifiUser %s", user.Name))
+	r.Log.Debug("Adding Finalizer for the NifiUser",
+		zap.String("user", user.Name))
 	user.SetFinalizers(append(user.GetFinalizers(), userFinalizer))
 	return
 }

--- a/controllers/nifiusergroup_controller.go
+++ b/controllers/nifiusergroup_controller.go
@@ -88,10 +88,10 @@ func (r *NifiUserGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Create it if not exist.
 	if o == nil {
 		if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(instance); err != nil {
-			return RequeueWithError(r.Log, "could not apply last state to annotation", err)
+			return RequeueWithError(r.Log, "could not apply last state to annotation for user group "+instance.Name, err)
 		}
 		if err := r.Client.Update(ctx, instance); err != nil {
-			return RequeueWithError(r.Log, "failed to update NifiRegistryClient", err)
+			return RequeueWithError(r.Log, "failed to update NifiUserGroup "+instance.Name, err)
 		}
 		o, err = patch.DefaultAnnotator.GetOriginalConfiguration(instance)
 	}
@@ -113,9 +113,10 @@ func (r *NifiUserGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 			// This shouldn't trigger anymore, but leaving it here as a safetybelt
 			if k8sutil.IsMarkedForDeletion(current.ObjectMeta) {
-				r.Log.Info("User is already gone, there is nothing we can do")
+				r.Log.Error("User group is already gone, there is nothing we can do",
+					zap.String("userGroup", instance.Name))
 				if err = r.removeFinalizer(ctx, current); err != nil {
-					return RequeueWithError(r.Log, "failed to remove finalizer", err)
+					return RequeueWithError(r.Log, "failed to remove finalizer for user group "+instance.Name, err)
 				}
 				return Reconciled()
 			}
@@ -125,19 +126,16 @@ func (r *NifiUserGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 					userRef.Name, userNamespace))
 
 			// the cluster does not exist - should have been caught pre-flight
-			return RequeueWithError(r.Log, "failed to lookup referenced user", err)
+			return RequeueWithError(r.Log, "failed to lookup referenced user "+user.Name+" in group "+instance.Name, err)
 		}
 
 		// Check if cluster references are the same
 		clusterNamespace := GetClusterRefNamespace(current.Namespace, current.Spec.ClusterRef)
 		if user != nil && (userNamespace != clusterNamespace || user.Spec.ClusterRef.Name != current.Spec.ClusterRef.Name) {
-			r.Recorder.Event(instance, corev1.EventTypeWarning, "ReferenceClusterError",
-				fmt.Sprintf("Failed to ensure consistency in cluster referece : %s in %s, with user : %s in %s",
-					instance.Spec.ClusterRef.Name, clusterNamespace, userRef.Name, userRef.Namespace))
-			return RequeueWithError(
-				r.Log,
-				"failed to lookup referenced cluster, due to inconsistency",
-				errors.New("inconsistent cluster references"))
+			msg := fmt.Sprintf("Failed to ensure consistency in cluster referece : %s in %s, with user : %s in %s",
+				instance.Spec.ClusterRef.Name, clusterNamespace, userRef.Name, userRef.Namespace)
+			r.Recorder.Event(instance, corev1.EventTypeWarning, "ReferenceClusterError", msg)
+			return RequeueWithError(r.Log, msg, errors.New("inconsistent cluster references"))
 		}
 
 		users = append(users, user)
@@ -156,9 +154,11 @@ func (r *NifiUserGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if clusterConnect, err = configManager.BuildConnect(); err != nil {
 		// This shouldn't trigger anymore, but leaving it here as a safetybelt
 		if k8sutil.IsMarkedForDeletion(instance.ObjectMeta) {
-			r.Log.Info("Cluster is already gone, there is nothing we can do")
+			r.Log.Error("Cluster is already gone, there is nothing we can do",
+				zap.String("userGroup", instance.Name),
+				zap.String("clusterName", clusterRef.Name))
 			if err = r.removeFinalizer(ctx, instance); err != nil {
-				return RequeueWithError(r.Log, "failed to remove finalizer", err)
+				return RequeueWithError(r.Log, "failed to remove finalizer for user group "+instance.Name, err)
 			}
 			return Reconciled()
 		}
@@ -166,10 +166,10 @@ func (r *NifiUserGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		// If the referenced cluster no more exist, just skip the deletion requirement in cluster ref change case.
 		if !v1alpha1.ClusterRefsEquals([]v1alpha1.ClusterReference{instance.Spec.ClusterRef, current.Spec.ClusterRef}) {
 			if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(current); err != nil {
-				return RequeueWithError(r.Log, "could not apply last state to annotation", err)
+				return RequeueWithError(r.Log, "could not apply last state to annotation for user group "+instance.Name, err)
 			}
 			if err := r.Client.Update(ctx, current); err != nil {
-				return RequeueWithError(r.Log, "failed to update NifiDataflow", err)
+				return RequeueWithError(r.Log, "failed to update NifiUserGroup "+instance.Name, err)
 			}
 			return RequeueAfter(time.Duration(15) * time.Second)
 		}
@@ -179,7 +179,7 @@ func (r *NifiUserGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				instance.Spec.ClusterRef.Name, clusterRef.Namespace))
 
 		// the cluster does not exist - should have been caught pre-flight
-		return RequeueWithError(r.Log, "failed to lookup referenced cluster", err)
+		return RequeueWithError(r.Log, "failed to lookup referenced cluster for user group "+instance.Name, err)
 	}
 
 	// Generate the client configuration.
@@ -196,7 +196,7 @@ func (r *NifiUserGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return Reconciled()
 		}
 		// the cluster does not exist - should have been caught pre-flight
-		return RequeueWithError(r.Log, "failed to create HTTP client the for referenced cluster", err)
+		return RequeueWithError(r.Log, "failed to create HTTP client the for referenced cluster "+clusterRef.Name+" for user group "+instance.Name, err)
 	}
 
 	// Check if marked for deletion and if so run finalizers
@@ -206,7 +206,9 @@ func (r *NifiUserGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Ensure the cluster is ready to receive actions
 	if !clusterConnect.IsReady(r.Log) {
-		r.Log.Info("Cluster is not ready yet, will wait until it is.")
+		r.Log.Debug("Cluster is not ready yet, will wait until it is.",
+			zap.String("userGroup", instance.Name),
+			zap.String("clusterName", clusterRef.Name))
 		r.Recorder.Event(instance, corev1.EventTypeNormal, "ReferenceClusterNotReady",
 			fmt.Sprintf("The referenced cluster is not ready yet : %s in %s",
 				instance.Spec.ClusterRef.Name, clusterConnect.Id()))
@@ -218,17 +220,17 @@ func (r *NifiUserGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if !v1alpha1.ClusterRefsEquals([]v1alpha1.ClusterReference{instance.Spec.ClusterRef, current.Spec.ClusterRef}) {
 		// Delete the resource on the previous cluster.
 		if err := usergroup.RemoveUserGroup(instance, users, clientConfig); err != nil {
-			r.Recorder.Event(instance, corev1.EventTypeWarning, "RemoveError",
-				fmt.Sprintf("Failed to delete NifiRegistryClient %s from cluster %s before moving in %s",
-					instance.Name, original.Spec.ClusterRef.Name, original.Spec.ClusterRef.Name))
-			return RequeueWithError(r.Log, "Failed to delete NifiRegistryClient before moving", err)
+			msg := fmt.Sprintf("Failed to delete NifiUserGroup %s from cluster %s before moving in %s",
+				instance.Name, original.Spec.ClusterRef.Name, original.Spec.ClusterRef.Namespace)
+			r.Recorder.Event(instance, corev1.EventTypeWarning, "RemoveError", msg)
+			return RequeueWithError(r.Log, msg, err)
 		}
 		// Update the last view configuration to the current one.
 		if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(current); err != nil {
-			return RequeueWithError(r.Log, "could not apply last state to annotation", err)
+			return RequeueWithError(r.Log, "could not apply last state to annotation for user group "+instance.Name, err)
 		}
 		if err := r.Client.Update(ctx, current); err != nil {
-			return RequeueWithError(r.Log, "failed to update NifiRegistryClient", err)
+			return RequeueWithError(r.Log, "failed to update NifiUserGroup "+instance.Name, err)
 		}
 		return RequeueAfter(interval)
 	}
@@ -239,7 +241,7 @@ func (r *NifiUserGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Check if the NiFi user group already exist
 	exist, err := usergroup.ExistUserGroup(instance, clientConfig)
 	if err != nil {
-		return RequeueWithError(r.Log, "failure checking for existing user group", err)
+		return RequeueWithError(r.Log, "failure checking for existing user group "+instance.Name, err)
 	}
 
 	if !exist {
@@ -249,12 +251,12 @@ func (r *NifiUserGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		// Create NiFi user group
 		status, err := usergroup.CreateUserGroup(instance, users, clientConfig)
 		if err != nil {
-			return RequeueWithError(r.Log, "failure creating user group", err)
+			return RequeueWithError(r.Log, "failure creating user group "+instance.Name, err)
 		}
 
 		instance.Status = *status
 		if err := r.Client.Status().Update(ctx, instance); err != nil {
-			return RequeueWithError(r.Log, "failed to update NifiUserGroup status", err)
+			return RequeueWithError(r.Log, "failed to update status for NifiUserGroup "+instance.Name, err)
 		}
 
 		r.Recorder.Event(instance, corev1.EventTypeNormal, "Created",
@@ -268,12 +270,12 @@ func (r *NifiUserGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if err != nil {
 		r.Recorder.Event(instance, corev1.EventTypeNormal, "SynchronizingFailed",
 			fmt.Sprintf("Synchronizing user group %s failed", instance.Name))
-		return RequeueWithError(r.Log, "failed to sync NifiUserGroup", err)
+		return RequeueWithError(r.Log, "failed to sync NifiUserGroup "+instance.Name, err)
 	}
 
 	instance.Status = *status
 	if err := r.Client.Status().Update(ctx, instance); err != nil {
-		return RequeueWithError(r.Log, "failed to update NifiUserGroup status", err)
+		return RequeueWithError(r.Log, "failed to update status for NifiUserGroup "+instance.Name, err)
 	}
 
 	r.Recorder.Event(instance, corev1.EventTypeNormal, "Synchronized",
@@ -281,24 +283,26 @@ func (r *NifiUserGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Ensure NifiCluster label
 	if instance, err = r.ensureClusterLabel(ctx, clusterConnect, instance); err != nil {
-		return RequeueWithError(r.Log, "failed to ensure NifiCluster label on user group", err)
+		return RequeueWithError(r.Log, "failed to ensure NifiCluster label on user group "+instance.Name, err)
 	}
 
 	// Ensure finalizer for cleanup on deletion
 	if !util.StringSliceContains(instance.GetFinalizers(), userGroupFinalizer) {
-		r.Log.Info("Adding Finalizer for NifiUserGroup")
+		r.Log.Info("Adding Finalizer for NifiUserGroup",
+			zap.String("userGroup", instance.Name))
 		instance.SetFinalizers(append(instance.GetFinalizers(), userGroupFinalizer))
 	}
 
 	// Push any changes
 	if instance, err = r.updateAndFetchLatest(ctx, instance); err != nil {
-		return RequeueWithError(r.Log, "failed to update NifiUserGroup", err)
+		return RequeueWithError(r.Log, "failed to update NifiUserGroup "+instance.Name, err)
 	}
 
 	r.Recorder.Event(instance, corev1.EventTypeNormal, "Reconciled",
 		fmt.Sprintf("Reconciling user group %s", instance.Name))
 
-	r.Log.Info("Ensured User Group")
+	r.Log.Debug("Ensured User Group",
+		zap.String("userGroup", instance.Name))
 
 	return RequeueAfter(interval)
 }
@@ -335,21 +339,23 @@ func (r *NifiUserGroupReconciler) updateAndFetchLatest(ctx context.Context,
 
 func (r *NifiUserGroupReconciler) checkFinalizers(ctx context.Context, userGroup *v1alpha1.NifiUserGroup,
 	users []*v1alpha1.NifiUser, config *clientconfig.NifiConfig) (reconcile.Result, error) {
-	r.Log.Info(fmt.Sprintf("NiFi user group %s is marked for deletion", userGroup.Name))
+	r.Log.Info("NiFi user group is marked for deletion. Removing finalizers.",
+		zap.String("userGroup", userGroup.Name))
 	var err error
 	if util.StringSliceContains(userGroup.GetFinalizers(), userGroupFinalizer) {
 		if err = r.finalizeNifiNifiUserGroup(userGroup, users, config); err != nil {
-			return RequeueWithError(r.Log, "failed to finalize nifiusergroup", err)
+			return RequeueWithError(r.Log, "failed to finalize nifiusergroup "+userGroup.Name, err)
 		}
 		if err = r.removeFinalizer(ctx, userGroup); err != nil {
-			return RequeueWithError(r.Log, "failed to remove finalizer from kafkatopic", err)
+			return RequeueWithError(r.Log, "failed to remove finalizer from user group"+userGroup.Name, err)
 		}
 	}
 	return Reconciled()
 }
 
 func (r *NifiUserGroupReconciler) removeFinalizer(ctx context.Context, userGroup *v1alpha1.NifiUserGroup) error {
-	r.Log.Info(fmt.Sprintf("Removing finalizer for NifiUserGroup %s", userGroup.Name))
+	r.Log.Debug("Removing finalizer for NifiUserGroup",
+		zap.String("userGroup", userGroup.Name))
 	userGroup.SetFinalizers(util.StringSliceRemove(userGroup.GetFinalizers(), userGroupFinalizer))
 	_, err := r.updateAndFetchLatest(ctx, userGroup)
 	return err
@@ -364,7 +370,8 @@ func (r *NifiUserGroupReconciler) finalizeNifiNifiUserGroup(
 		return err
 	}
 
-	r.Log.Info("Delete Registry client")
+	r.Log.Info("Deleted NifiUserGroup",
+		zap.String("userGroup", userGroup.Name))
 
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -73,7 +73,8 @@ func main() {
 	// Add support for MultiNamespace set in WATCH_NAMESPACE (e.g ns1,ns2)
 	var namespaceList []string
 	if watchNamespace != "" {
-		logger.Info("WATCH_NAMESPACE ENV provided, will watch and manage resources in defined namespaces", zap.String("namespaces", watchNamespace))
+		logger.Info("WATCH_NAMESPACE ENV provided, will watch and manage resources in defined namespaces",
+			zap.String("namespaces", watchNamespace))
 		namespaceList = strings.Split(watchNamespace, ",")
 
 		for i := range namespaceList {

--- a/pkg/clientwrappers/common.go
+++ b/pkg/clientwrappers/common.go
@@ -1,30 +1,36 @@
 package clientwrappers
 
 import (
-	"fmt"
-
 	"github.com/konpyutaika/nifikop/pkg/nificlient"
 	"go.uber.org/zap"
 )
 
 func ErrorUpdateOperation(log *zap.Logger, err error, action string) error {
 	if err == nificlient.ErrNifiClusterNotReturned200 {
-		log.Error(fmt.Sprintf("%s failed since Nifi node returned non 200", action), zap.Error(err))
+		log.Error("failed since Nifi node returned non 200",
+			zap.String("action", action),
+			zap.Error(err))
 	}
 
 	if err != nil {
-		log.Error("could not communicate with nifi node", zap.Error(err))
+		log.Error("could not communicate with nifi node",
+			zap.String("action", action),
+			zap.Error(err))
 	}
 	return err
 }
 
 func ErrorGetOperation(log *zap.Logger, err error, action string) error {
 	if err == nificlient.ErrNifiClusterNotReturned200 {
-		log.Error(fmt.Sprintf("%s failed since Nifi node returned non 200", action), zap.Error(err))
+		log.Error("failed since Nifi node returned non 200",
+			zap.String("action", action),
+			zap.Error(err))
 	}
 
 	if err != nil {
-		log.Error("could not communicate with nifi node", zap.Error(err))
+		log.Error("could not communicate with nifi node",
+			zap.String("action", action),
+			zap.Error(err))
 	}
 
 	return err
@@ -32,11 +38,15 @@ func ErrorGetOperation(log *zap.Logger, err error, action string) error {
 
 func ErrorCreateOperation(log *zap.Logger, err error, action string) error {
 	if err == nificlient.ErrNifiClusterNotReturned201 {
-		log.Error(fmt.Sprintf("%s request failed since Nifi node returned non 201", action), zap.Error(err))
+		log.Error("failed since Nifi node returned non 201",
+			zap.String("action", action),
+			zap.Error(err))
 	}
 
 	if err != nil {
-		log.Error("could not communicate with nifi node", zap.Error(err))
+		log.Error("could not communicate with nifi node",
+			zap.String("action", action),
+			zap.Error(err))
 	}
 
 	return err
@@ -44,11 +54,15 @@ func ErrorCreateOperation(log *zap.Logger, err error, action string) error {
 
 func ErrorRemoveOperation(log *zap.Logger, err error, action string) error {
 	if err == nificlient.ErrNifiClusterNotReturned200 {
-		log.Error(fmt.Sprintf("%s failed since Nifi node returned non 200", action), zap.Error(err))
+		log.Error("failed since Nifi node returned non 200",
+			zap.String("action", action),
+			zap.Error(err))
 	}
 
 	if err != nil {
-		log.Error("could not communicate with nifi node", zap.Error(err))
+		log.Error("could not communicate with nifi node",
+			zap.String("action", action),
+			zap.Error(err))
 	}
 
 	return err

--- a/pkg/clientwrappers/parametercontext/parametercontext.go
+++ b/pkg/clientwrappers/parametercontext/parametercontext.go
@@ -145,7 +145,7 @@ func RemoveParameterContext(parameterContext *v1alpha1.NifiParameterContext, par
 	}
 
 	entity, err := nClient.GetParameterContext(parameterContext.Status.Id)
-	if err := clientwrappers.ErrorGetOperation(log, err, "Get parameter-context"); err != nil {
+	if err := clientwrappers.ErrorGetOperation(log, err, "Failed to fetch parameter-context for removal: "+parameterContext.Name); err != nil {
 		if err == nificlient.ErrNifiClusterReturned404 {
 			return nil
 		}
@@ -155,7 +155,7 @@ func RemoveParameterContext(parameterContext *v1alpha1.NifiParameterContext, par
 	updateParameterContextEntity(parameterContext, parameterSecrets, entity)
 	err = nClient.RemoveParameterContext(*entity)
 
-	return clientwrappers.ErrorRemoveOperation(log, err, "Remove parameter-context")
+	return clientwrappers.ErrorRemoveOperation(log, err, "Failed to remove parameter-context "+parameterContext.Name)
 }
 
 func parameterContextIsSync(

--- a/pkg/clientwrappers/registryclient/registryclient.go
+++ b/pkg/clientwrappers/registryclient/registryclient.go
@@ -44,7 +44,7 @@ func CreateRegistryClient(registryClient *v1alpha1.NifiRegistryClient,
 	updateRegistryClientEntity(registryClient, &scratchEntity)
 
 	entity, err := nClient.CreateRegistryClient(scratchEntity)
-	if err := clientwrappers.ErrorCreateOperation(log, err, "Create registry-client"); err != nil {
+	if err := clientwrappers.ErrorCreateOperation(log, err, "Failed to create registry-client "+registryClient.Name); err != nil {
 		return nil, err
 	}
 

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -53,7 +53,7 @@ var NewNifiFromConfig = nificlient.NewFromConfig
 func NewClusterConnection(log *zap.Logger, config *clientconfig.NifiConfig) (node nificlient.NifiClient, err error) {
 
 	// Get a nifi connection
-	node, err = NewNifiFromConfig(config)
+	node, err = NewNifiFromConfig(config, CustomLogger().Named("nifi_client"))
 	if err != nil {
 		return
 	}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -109,7 +109,7 @@ func NewLogLevel(lvl string) (zapcore.Level, bool) {
 
 func CustomLogger() *zap.Logger {
 
-	logLvl, isDevelopment := NewLogLevel(util.GetEnvWithDefault("LOG_LEVEL", "Debug"))
+	logLvl, isDevelopment := NewLogLevel(util.GetEnvWithDefault("LOG_LEVEL", "Info"))
 	logEncoding := util.GetEnvWithDefault("LOG_ENCODING", "json")
 
 	conf := zap.Config{

--- a/pkg/k8sutil/resource.go
+++ b/pkg/k8sutil/resource.go
@@ -51,7 +51,10 @@ func Reconcile(log zap.Logger, client runtimeClient.Client, desired runtimeClien
 					"kind", desiredType, "name", key.Name,
 				)
 			}
-			log.Info("resource created")
+			log.Info("resource created",
+				zap.String("name", desired.GetName()),
+				zap.String("namespace", desired.GetNamespace()),
+				zap.String("kind", desired.GetObjectKind().GroupVersionKind().Kind))
 			return nil
 		}
 	}
@@ -109,7 +112,10 @@ func Reconcile(log zap.Logger, client runtimeClient.Client, desired runtimeClien
 			}
 		}
 
-		log.Info("resource updated")
+		log.Debug("resource updated",
+			zap.String("name", desired.GetName()),
+			zap.String("namespace", desired.GetNamespace()),
+			zap.String("kind", desired.GetObjectKind().GroupVersionKind().Kind))
 	}
 	return nil
 }
@@ -121,10 +127,10 @@ func CheckIfObjectUpdated(log zap.Logger, desiredType reflect.Type, current, des
 		log.Error("could not match objects", zap.Error(err), zap.String("kind", desiredType.String()))
 		return true
 	} else if patchResult.IsEmpty() {
-		log.Debug("resource is in sync")
+		log.Debug("resource is in sync", zap.String("kind", desiredType.String()))
 		return false
 	} else {
-		log.Info("resource diffs",
+		log.Debug("resource diffs",
 			zap.String("patch", string(patchResult.Patch)),
 			zap.String("current", string(patchResult.Current)),
 			zap.String("modified", string(patchResult.Modified)),

--- a/pkg/k8sutil/status.go
+++ b/pkg/k8sutil/status.go
@@ -132,7 +132,9 @@ func UpdateNodeStatus(c client.Client, nodeIds []string, cluster *v1alpha1.NifiC
 	}
 	// update loses the typeMeta of the config that's used later when setting ownerrefs
 	cluster.TypeMeta = typeMeta
-	logger.Info("Nifi cluster state updated")
+	logger.Debug("Nifi cluster state updated",
+		zap.String("clusterName", cluster.Name),
+		zap.Strings("nodeIds", nodeIds))
 	return nil
 }
 

--- a/pkg/nificlient/access.go
+++ b/pkg/nificlient/access.go
@@ -3,6 +3,7 @@ package nificlient
 import (
 	"github.com/antihax/optional"
 	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
+	"go.uber.org/zap"
 )
 
 func (n *nifiClient) CreateAccessTokenUsingBasicAuth(username, password string, nodeId int32) (*string, error) {
@@ -11,7 +12,9 @@ func (n *nifiClient) CreateAccessTokenUsingBasicAuth(username, password string, 
 	client := n.nodeClient[nodeId]
 	context := n.opts.NodesContext[nodeId]
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client",
+			zap.Int32("nodeId", nodeId),
+			zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
@@ -21,7 +24,7 @@ func (n *nifiClient) CreateAccessTokenUsingBasicAuth(username, password string, 
 		Password: optional.NewString(password),
 	})
 
-	if err := errorCreateOperation(rsp, body, err); err != nil {
+	if err := errorCreateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 	return body, nil

--- a/pkg/nificlient/client.go
+++ b/pkg/nificlient/client.go
@@ -8,14 +8,12 @@ import (
 	"time"
 
 	"emperror.dev/errors"
-	"github.com/konpyutaika/nifikop/pkg/util/clientconfig"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"go.uber.org/zap"
 
 	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
 	"github.com/konpyutaika/nifikop/pkg/errorfactory"
+	"github.com/konpyutaika/nifikop/pkg/util/clientconfig"
 )
-
-var log = ctrl.Log.WithName("nifi_client")
 
 const (
 	PRIMARY_NODE        = "Primary Node"
@@ -136,6 +134,7 @@ type NifiClient interface {
 
 type nifiClient struct {
 	NifiClient
+	log        *zap.Logger
 	opts       *clientconfig.NifiConfig
 	client     *nigoapi.APIClient
 	nodeClient map[int32]*nigoapi.APIClient
@@ -146,8 +145,9 @@ type nifiClient struct {
 	newClient func(*nigoapi.Configuration) *nigoapi.APIClient
 }
 
-func New(opts *clientconfig.NifiConfig) NifiClient {
+func New(opts *clientconfig.NifiConfig, logger *zap.Logger) NifiClient {
 	nClient := &nifiClient{
+		log:     logger,
 		opts:    opts,
 		timeout: time.Duration(opts.OperationTimeout) * time.Second,
 	}
@@ -180,14 +180,14 @@ func (n *nifiClient) Build() error {
 }
 
 // NewFromConfig is a convenient wrapper around New() and ClusterConfig()
-func NewFromConfig(opts *clientconfig.NifiConfig) (NifiClient, error) {
+func NewFromConfig(opts *clientconfig.NifiConfig, logger *zap.Logger) (NifiClient, error) {
 	var client NifiClient
 	var err error
 
 	if opts == nil {
 		return nil, errorfactory.New(errorfactory.NilClientConfig{}, errors.New("The NiFi client config is nil"), "The NiFi client config is nil")
 	}
-	client = New(opts)
+	client = New(opts, logger)
 	err = client.Build()
 	if err != nil {
 		return nil, err

--- a/pkg/nificlient/client_test.go
+++ b/pkg/nificlient/client_test.go
@@ -2,10 +2,12 @@ package nificlient
 
 import (
 	"fmt"
-	"github.com/konpyutaika/nifikop/pkg/util/clientconfig"
 	"net/http"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
+
+	"github.com/konpyutaika/nifikop/pkg/util/clientconfig"
+	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
 	"github.com/jarcoal/httpmock"
@@ -34,7 +36,7 @@ var (
 
 func TestNew(t *testing.T) {
 	opts := newMockOpts()
-	if client := New(opts); client == nil {
+	if client := New(opts, &zap.Logger{}); client == nil {
 		t.Error("Expected new client, got nil")
 	}
 }

--- a/pkg/nificlient/client_test.go
+++ b/pkg/nificlient/client_test.go
@@ -36,7 +36,7 @@ var (
 
 func TestNew(t *testing.T) {
 	opts := newMockOpts()
-	if client := New(opts, &zap.Logger{}); client == nil {
+	if client := New(opts, zap.NewNop()); client == nil {
 		t.Error("Expected new client, got nil")
 	}
 }

--- a/pkg/nificlient/common.go
+++ b/pkg/nificlient/common.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"emperror.dev/errors"
+	"go.uber.org/zap"
 )
 
 var ErrNodeNotConnected = errors.New("The targeted node id disconnected")
@@ -14,65 +15,79 @@ var ErrNifiClusterNodeNotFound = errors.New("The target node id doesn't exist in
 
 var ErrNoNodeClientsAvailable = errors.New("Cannot create a node client to perform actions")
 
-func errorGetOperation(rsp *http.Response, body *string, err error) error {
+func errorGetOperation(rsp *http.Response, body *string, err error, log *zap.Logger) error {
 	if rsp != nil && rsp.StatusCode == 404 {
-		log.Info("404 response from nifi node: " + rsp.Status)
+		log.Error("404 response from nifi node: ",
+			zap.String("statusCode", rsp.Status))
 		return ErrNifiClusterReturned404
 	}
 
 	if rsp != nil && rsp.StatusCode != 200 {
-		log.Error(errors.New("Non 200 response from nifi node: "+rsp.Status), *body)
+		log.Error("Non 200 response from nifi node",
+			zap.String("statusCode", rsp.Status),
+			zap.Stringp("body", body))
 		return ErrNifiClusterNotReturned200
 	}
 
 	if err != nil || rsp == nil {
-		log.Error(err, "Error during talking to nifi node")
+		log.Error("Error during talking to nifi node",
+			zap.Error(err))
 		return err
 	}
 	return nil
 }
 
-func errorCreateOperation(rsp *http.Response, body *string, err error) error {
+func errorCreateOperation(rsp *http.Response, body *string, err error, log *zap.Logger) error {
 	if rsp != nil && rsp.StatusCode != 201 {
-		log.Error(errors.New("Non 201 response from nifi node: "+rsp.Status), *body)
+		log.Error("Non 201 response from nifi node",
+			zap.String("statusCode", rsp.Status),
+			zap.Stringp("body", body))
 		return ErrNifiClusterNotReturned201
 	}
 
 	if err != nil || rsp == nil {
-		log.Error(err, "Error during talking to nifi node")
+		log.Error("Error during talking to nifi node",
+			zap.Error(err))
 		return err
 	}
 
 	return nil
 }
 
-func errorUpdateOperation(rsp *http.Response, body *string, err error) error {
+func errorUpdateOperation(rsp *http.Response, body *string, err error, log *zap.Logger) error {
 	if rsp != nil && rsp.StatusCode != 200 && rsp.StatusCode != 202 {
-		log.Error(errors.New("Non 200 response from nifi node: "+rsp.Status), *body)
+		log.Error("Non 200 or 202 response from nifi node",
+			zap.String("statusCode", rsp.Status),
+			zap.Stringp("body", body))
 		return ErrNifiClusterNotReturned200
 	}
 
 	if err != nil || rsp == nil {
-		log.Error(err, "Error during talking to nifi node")
+		log.Error("Error during talking to nifi node",
+			zap.Error(err))
 		return err
 	}
 
 	return nil
 }
 
-func errorDeleteOperation(rsp *http.Response, body *string, err error) error {
+func errorDeleteOperation(rsp *http.Response, body *string, err error, log *zap.Logger) error {
 	if rsp != nil && rsp.StatusCode == 404 {
-		log.Error(errors.New("404 response from nifi node: "+rsp.Status), *body)
+		log.Error("404 response from nifi node: ",
+			zap.String("statusCode", rsp.Status))
 		return nil
 	}
 
 	if rsp != nil && rsp.StatusCode != 200 {
-		log.Error(errors.New("Non 200 response from nifi node: "+rsp.Status), *body)
+		log.Error("Non 200 response from nifi node",
+			zap.String("statusCode", rsp.Status),
+			zap.Stringp("body", body))
 		return ErrNifiClusterNotReturned200
 	}
 
 	if err != nil || rsp == nil {
-		log.Error(err, "Error during talking to nifi node")
+		log.Error("Error during talking to nifi node",
+			zap.Error(err))
 		return err
 	}
 

--- a/pkg/nificlient/config/tls/tls_config.go
+++ b/pkg/nificlient/config/tls/tls_config.go
@@ -7,11 +7,8 @@ import (
 	"github.com/konpyutaika/nifikop/pkg/nificlient/config/nificluster"
 	"github.com/konpyutaika/nifikop/pkg/util"
 	"github.com/konpyutaika/nifikop/pkg/util/clientconfig"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-var log = ctrl.Log.WithName("tls_config")
 
 func (n *tls) BuildConfig() (*clientconfig.NifiConfig, error) {
 	var cluster *v1alpha1.NifiCluster

--- a/pkg/nificlient/controllerconfig.go
+++ b/pkg/nificlient/controllerconfig.go
@@ -2,13 +2,15 @@ package nificlient
 
 import (
 	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
+	"go.uber.org/zap"
 )
 
 func (n *nifiClient) GetControllerConfig() (*nigoapi.ControllerConfigurationEntity, error) {
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client",
+			zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
@@ -16,7 +18,7 @@ func (n *nifiClient) GetControllerConfig() (*nigoapi.ControllerConfigurationEnti
 
 	out, rsp, body, err := client.ControllerApi.GetControllerConfig(context)
 
-	if err := errorGetOperation(rsp, body, err); err != nil {
+	if err := errorGetOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -27,13 +29,13 @@ func (n *nifiClient) UpdateControllerConfig(entity nigoapi.ControllerConfigurati
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to update the reporting task
 	out, rsp, body, err := client.ControllerApi.UpdateControllerConfig(context, entity)
-	if err := errorUpdateOperation(rsp, body, err); err != nil {
+	if err := errorUpdateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 

--- a/pkg/nificlient/flow.go
+++ b/pkg/nificlient/flow.go
@@ -3,19 +3,21 @@ package nificlient
 import (
 	"github.com/antihax/optional"
 	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
+	"go.uber.org/zap"
 )
 
 func (n *nifiClient) GetFlow(id string) (*nigoapi.ProcessGroupFlowEntity, error) {
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client",
+			zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to get the process group flow informations
 	flowPGEntity, rsp, body, err := client.FlowApi.GetFlow(context, id)
-	if err := errorGetOperation(rsp, body, err); err != nil {
+	if err := errorGetOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -26,7 +28,7 @@ func (n *nifiClient) GetFlowControllerServices(id string) (*nigoapi.ControllerSe
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
@@ -37,7 +39,7 @@ func (n *nifiClient) GetFlowControllerServices(id string) (*nigoapi.ControllerSe
 			IncludeDescendantGroups: optional.NewBool(true),
 		})
 
-	if err := errorGetOperation(rsp, body, err); err != nil {
+	if err := errorGetOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -49,13 +51,14 @@ func (n *nifiClient) UpdateFlowControllerServices(entity nigoapi.ActivateControl
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client",
+			zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to enable or disable the controller services
 	csEntity, rsp, body, err := client.FlowApi.ActivateControllerServices(context, entity.Id, entity)
-	if err := errorUpdateOperation(rsp, body, err); err != nil {
+	if err := errorUpdateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -67,13 +70,14 @@ func (n *nifiClient) UpdateFlowProcessGroup(entity nigoapi.ScheduleComponentsEnt
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client",
+			zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to enable or disable the controller services
 	csEntity, rsp, body, err := client.FlowApi.ScheduleComponents(context, entity.Id, entity)
-	if err := errorUpdateOperation(rsp, body, err); err != nil {
+	if err := errorUpdateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 

--- a/pkg/nificlient/flowfiles.go
+++ b/pkg/nificlient/flowfiles.go
@@ -2,19 +2,20 @@ package nificlient
 
 import (
 	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
+	"go.uber.org/zap"
 )
 
 func (n *nifiClient) GetDropRequest(connectionId, id string) (*nigoapi.DropRequestEntity, error) {
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to get the drop request information
 	dropRequest, rsp, body, err := client.FlowfileQueuesApi.GetDropRequest(context, connectionId, id)
-	if err := errorGetOperation(rsp, body, err); err != nil {
+	if err := errorGetOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -25,13 +26,13 @@ func (n *nifiClient) CreateDropRequest(connectionId string) (*nigoapi.DropReques
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to create the drop Request
 	entity, rsp, body, err := client.FlowfileQueuesApi.CreateDropRequest(context, connectionId)
-	if err := errorCreateOperation(rsp, body, err); err != nil {
+	if err := errorCreateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 

--- a/pkg/nificlient/inputport.go
+++ b/pkg/nificlient/inputport.go
@@ -1,18 +1,21 @@
 package nificlient
 
-import nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
+import (
+	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
+	"go.uber.org/zap"
+)
 
 func (n *nifiClient) UpdateInputPortRunStatus(id string, entity nigoapi.PortRunStatusEntity) (*nigoapi.ProcessorEntity, error) {
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to update the input port run status
 	processor, rsp, body, err := client.InputPortsApi.UpdateRunStatus(context, id, entity)
-	if err := errorUpdateOperation(rsp, body, err); err != nil {
+	if err := errorUpdateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 

--- a/pkg/nificlient/mock_client_test.go
+++ b/pkg/nificlient/mock_client_test.go
@@ -1,9 +1,11 @@
 package nificlient
 
 import (
+	"testing"
+
 	"github.com/konpyutaika/nifikop/pkg/nificlient/config/common"
 	"github.com/konpyutaika/nifikop/pkg/util/clientconfig"
-	"testing"
+	"go.uber.org/zap"
 
 	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
 	"github.com/jarcoal/httpmock"
@@ -38,6 +40,7 @@ func newMockHttpClient(c *nigoapi.Configuration) *nigoapi.APIClient {
 
 func newMockClient() *nifiClient {
 	return &nifiClient{
+		log:       zap.NewNop(),
 		opts:      newMockOpts(),
 		newClient: newMockHttpClient,
 	}
@@ -51,6 +54,7 @@ func newBuildedMockClient() *nifiClient {
 
 func NewMockNiFiClient() *nifiClient {
 	return &nifiClient{
+		log:       zap.NewNop(),
 		opts:      newMockOpts(),
 		newClient: newMockHttpClient,
 	}

--- a/pkg/nificlient/parametercontext.go
+++ b/pkg/nificlient/parametercontext.go
@@ -5,19 +5,20 @@ import (
 
 	"github.com/antihax/optional"
 	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
+	"go.uber.org/zap"
 )
 
 func (n *nifiClient) GetParameterContexts() ([]nigoapi.ParameterContextEntity, error) {
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to get the parameter contexts informations
 	pcEntity, rsp, body, err := client.FlowApi.GetParameterContexts(context)
-	if err := errorGetOperation(rsp, body, err); err != nil {
+	if err := errorGetOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -28,13 +29,13 @@ func (n *nifiClient) GetParameterContext(id string) (*nigoapi.ParameterContextEn
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to get the parameter context informations
 	pcEntity, rsp, body, err := client.ParameterContextsApi.GetParameterContext(context, id)
-	if err := errorGetOperation(rsp, body, err); err != nil {
+	if err := errorGetOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -45,13 +46,13 @@ func (n *nifiClient) CreateParameterContext(entity nigoapi.ParameterContextEntit
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to create the parameter context
 	pcEntity, rsp, body, err := client.ParameterContextsApi.CreateParameterContext(context, entity)
-	if err := errorCreateOperation(rsp, body, err); err != nil {
+	if err := errorCreateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -62,7 +63,7 @@ func (n *nifiClient) RemoveParameterContext(entity nigoapi.ParameterContextEntit
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return ErrNoNodeClientsAvailable
 	}
 
@@ -72,20 +73,20 @@ func (n *nifiClient) RemoveParameterContext(entity nigoapi.ParameterContextEntit
 			Version: optional.NewString(strconv.FormatInt(*entity.Revision.Version, 10)),
 		})
 
-	return errorDeleteOperation(rsp, body, err)
+	return errorDeleteOperation(rsp, body, err, n.log)
 }
 
 func (n *nifiClient) CreateParameterContextUpdateRequest(contextId string, entity nigoapi.ParameterContextEntity) (*nigoapi.ParameterContextUpdateRequestEntity, error) {
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to create the parameter context update request
 	request, rsp, body, err := client.ParameterContextsApi.SubmitParameterContextUpdate(context, contextId, entity)
-	if err := errorUpdateOperation(rsp, body, err); err != nil {
+	if err := errorUpdateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -96,13 +97,13 @@ func (n *nifiClient) GetParameterContextUpdateRequest(contextId, id string) (*ni
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to get the parameter context update request information
 	request, rsp, body, err := client.ParameterContextsApi.GetParameterContextUpdate(context, contextId, id)
-	if err := errorGetOperation(rsp, body, err); err != nil {
+	if err := errorGetOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 

--- a/pkg/nificlient/policies.go
+++ b/pkg/nificlient/policies.go
@@ -5,13 +5,14 @@ import (
 
 	"github.com/antihax/optional"
 	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
+	"go.uber.org/zap"
 )
 
 func (n *nifiClient) GetAccessPolicy(action, resource string) (*nigoapi.AccessPolicyEntity, error) {
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
@@ -27,7 +28,7 @@ func (n *nifiClient) GetAccessPolicy(action, resource string) (*nigoapi.AccessPo
 
 	accessPolicyEntity, rsp, body, err := client.PoliciesApi.GetAccessPolicyForResource(context, action, resource)
 
-	if err := errorGetOperation(rsp, body, err); err != nil {
+	if err := errorGetOperation(rsp, body, err, n.log.WithOptions()); err != nil {
 		return nil, err
 	}
 
@@ -38,13 +39,13 @@ func (n *nifiClient) CreateAccessPolicy(entity nigoapi.AccessPolicyEntity) (*nig
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to create the access policy
 	accessPolicyEntity, rsp, body, err := client.PoliciesApi.CreateAccessPolicy(context, entity)
-	if err := errorCreateOperation(rsp, body, err); err != nil {
+	if err := errorCreateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -55,13 +56,13 @@ func (n *nifiClient) UpdateAccessPolicy(entity nigoapi.AccessPolicyEntity) (*nig
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to update the access policy
 	accessPolicyEntity, rsp, body, err := client.PoliciesApi.UpdateAccessPolicy(context, entity.Id, entity)
-	if err := errorUpdateOperation(rsp, body, err); err != nil {
+	if err := errorUpdateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -72,7 +73,7 @@ func (n *nifiClient) RemoveAccessPolicy(entity nigoapi.AccessPolicyEntity) error
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return ErrNoNodeClientsAvailable
 	}
 
@@ -82,5 +83,5 @@ func (n *nifiClient) RemoveAccessPolicy(entity nigoapi.AccessPolicyEntity) error
 			Version: optional.NewString(strconv.FormatInt(*entity.Revision.Version, 10)),
 		})
 
-	return errorDeleteOperation(rsp, body, err)
+	return errorDeleteOperation(rsp, body, err, n.log)
 }

--- a/pkg/nificlient/processgroup.go
+++ b/pkg/nificlient/processgroup.go
@@ -5,19 +5,20 @@ import (
 
 	"github.com/antihax/optional"
 	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
+	"go.uber.org/zap"
 )
 
 func (n *nifiClient) GetProcessGroup(id string) (*nigoapi.ProcessGroupEntity, error) {
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to get the process group informations
 	pGEntity, rsp, body, err := client.ProcessGroupsApi.GetProcessGroup(context, id)
-	if err := errorGetOperation(rsp, body, err); err != nil {
+	if err := errorGetOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -30,13 +31,13 @@ func (n *nifiClient) CreateProcessGroup(
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to create the versioned process group
 	pgEntity, rsp, body, err := client.ProcessGroupsApi.CreateProcessGroup(context, pgParentId, entity)
-	if err := errorCreateOperation(rsp, body, err); err != nil {
+	if err := errorCreateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -47,13 +48,13 @@ func (n *nifiClient) UpdateProcessGroup(entity nigoapi.ProcessGroupEntity) (*nig
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to update the versioned process group
 	pgEntity, rsp, body, err := client.ProcessGroupsApi.UpdateProcessGroup(context, entity.Id, entity)
-	if err := errorUpdateOperation(rsp, body, err); err != nil {
+	if err := errorUpdateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -64,7 +65,7 @@ func (n *nifiClient) RemoveProcessGroup(entity nigoapi.ProcessGroupEntity) error
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return ErrNoNodeClientsAvailable
 	}
 
@@ -76,5 +77,5 @@ func (n *nifiClient) RemoveProcessGroup(entity nigoapi.ProcessGroupEntity) error
 			Version: optional.NewString(strconv.FormatInt(*entity.Revision.Version, 10)),
 		})
 
-	return errorDeleteOperation(rsp, body, err)
+	return errorDeleteOperation(rsp, body, err, n.log)
 }

--- a/pkg/nificlient/processor.go
+++ b/pkg/nificlient/processor.go
@@ -1,6 +1,9 @@
 package nificlient
 
-import nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
+import (
+	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
+	"go.uber.org/zap"
+)
 
 func (n *nifiClient) UpdateProcessorRunStatus(
 	id string,
@@ -9,13 +12,13 @@ func (n *nifiClient) UpdateProcessorRunStatus(
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to update the processor run status
 	processor, rsp, body, err := client.ProcessorsApi.UpdateRunStatus(context, id, entity)
-	if err := errorUpdateOperation(rsp, body, err); err != nil {
+	if err := errorUpdateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 

--- a/pkg/nificlient/registryclient.go
+++ b/pkg/nificlient/registryclient.go
@@ -5,20 +5,21 @@ import (
 
 	"github.com/antihax/optional"
 	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
+	"go.uber.org/zap"
 )
 
 func (n *nifiClient) GetRegistryClient(id string) (*nigoapi.RegistryClientEntity, error) {
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to get the registy client informations
 	regCliEntity, rsp, body, err := client.ControllerApi.GetRegistryClient(context, id)
 
-	if err := errorGetOperation(rsp, body, err); err != nil {
+	if err := errorGetOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -29,13 +30,13 @@ func (n *nifiClient) CreateRegistryClient(entity nigoapi.RegistryClientEntity) (
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to create the registry client
 	regCliEntity, rsp, body, err := client.ControllerApi.CreateRegistryClient(context, entity)
-	if err := errorCreateOperation(rsp, body, err); err != nil {
+	if err := errorCreateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -46,13 +47,13 @@ func (n *nifiClient) UpdateRegistryClient(entity nigoapi.RegistryClientEntity) (
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to update the registry client
 	regCliEntity, rsp, body, err := client.ControllerApi.UpdateRegistryClient(context, entity.Id, entity)
-	if err := errorUpdateOperation(rsp, body, err); err != nil {
+	if err := errorUpdateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -63,7 +64,7 @@ func (n *nifiClient) RemoveRegistryClient(entity nigoapi.RegistryClientEntity) e
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return ErrNoNodeClientsAvailable
 	}
 
@@ -73,5 +74,5 @@ func (n *nifiClient) RemoveRegistryClient(entity nigoapi.RegistryClientEntity) e
 			Version: optional.NewString(strconv.FormatInt(*entity.Revision.Version, 10)),
 		})
 
-	return errorDeleteOperation(rsp, body, err)
+	return errorDeleteOperation(rsp, body, err, n.log)
 }

--- a/pkg/nificlient/reportingtask.go
+++ b/pkg/nificlient/reportingtask.go
@@ -5,20 +5,21 @@ import (
 
 	"github.com/antihax/optional"
 	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
+	"go.uber.org/zap"
 )
 
 func (n *nifiClient) GetReportingTask(id string) (*nigoapi.ReportingTaskEntity, error) {
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to get the reporting task informations
 	out, rsp, body, err := client.ReportingTasksApi.GetReportingTask(context, id)
 
-	if err := errorGetOperation(rsp, body, err); err != nil {
+	if err := errorGetOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -29,13 +30,13 @@ func (n *nifiClient) CreateReportingTask(entity nigoapi.ReportingTaskEntity) (*n
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to create the reporting task
 	out, rsp, body, err := client.ControllerApi.CreateReportingTask(context, entity)
-	if err := errorCreateOperation(rsp, body, err); err != nil {
+	if err := errorCreateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -46,13 +47,13 @@ func (n *nifiClient) UpdateReportingTask(entity nigoapi.ReportingTaskEntity) (*n
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to update the reporting task
 	out, rsp, body, err := client.ReportingTasksApi.UpdateReportingTask(context, entity.Id, entity)
-	if err := errorUpdateOperation(rsp, body, err); err != nil {
+	if err := errorUpdateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -63,13 +64,13 @@ func (n *nifiClient) UpdateRunStatusReportingTask(id string, entity nigoapi.Repo
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to update the reporting task
 	out, rsp, body, err := client.ReportingTasksApi.UpdateRunStatus(context, id, entity)
-	if err := errorUpdateOperation(rsp, body, err); err != nil {
+	if err := errorUpdateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -80,7 +81,7 @@ func (n *nifiClient) RemoveReportingTask(entity nigoapi.ReportingTaskEntity) err
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return ErrNoNodeClientsAvailable
 	}
 
@@ -90,5 +91,5 @@ func (n *nifiClient) RemoveReportingTask(entity nigoapi.ReportingTaskEntity) err
 			Version: optional.NewString(strconv.FormatInt(*entity.Revision.Version, 10)),
 		})
 
-	return errorDeleteOperation(rsp, body, err)
+	return errorDeleteOperation(rsp, body, err, n.log)
 }

--- a/pkg/nificlient/snippet.go
+++ b/pkg/nificlient/snippet.go
@@ -1,18 +1,21 @@
 package nificlient
 
-import nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
+import (
+	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
+	"go.uber.org/zap"
+)
 
 func (n *nifiClient) CreateSnippet(entity nigoapi.SnippetEntity) (*nigoapi.SnippetEntity, error) {
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to create the snippet
 	snippetEntity, rsp, body, err := client.SnippetsApi.CreateSnippet(context, entity)
-	if err := errorCreateOperation(rsp, body, err); err != nil {
+	if err := errorCreateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -23,13 +26,13 @@ func (n *nifiClient) UpdateSnippet(entity nigoapi.SnippetEntity) (*nigoapi.Snipp
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to update the snippet
 	snippetEntity, rsp, body, err := client.SnippetsApi.UpdateSnippet(context, entity.Snippet.Id, entity)
-	if err := errorUpdateOperation(rsp, body, err); err != nil {
+	if err := errorUpdateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 

--- a/pkg/nificlient/system_test.go
+++ b/pkg/nificlient/system_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/konpyutaika/nifikop/api/v1alpha1"
 	nifiutil "github.com/konpyutaika/nifikop/pkg/util/nifi"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 )
 
 func TestDescribeCluster(t *testing.T) {
@@ -323,7 +324,7 @@ func testClientFromCluster(cluster *v1alpha1.NifiCluster, empty bool) (NifiClien
 				MockGetClusterResponse(cluster, empty))
 		})
 
-	cli, err := NewFromConfig(cfg)
+	cli, err := NewFromConfig(cfg, &zap.Logger{})
 	return cli, err
 }
 

--- a/pkg/nificlient/system_test.go
+++ b/pkg/nificlient/system_test.go
@@ -324,7 +324,7 @@ func testClientFromCluster(cluster *v1alpha1.NifiCluster, empty bool) (NifiClien
 				MockGetClusterResponse(cluster, empty))
 		})
 
-	cli, err := NewFromConfig(cfg, &zap.Logger{})
+	cli, err := NewFromConfig(cfg, zap.NewNop())
 	return cli, err
 }
 

--- a/pkg/nificlient/user.go
+++ b/pkg/nificlient/user.go
@@ -5,20 +5,21 @@ import (
 
 	"github.com/antihax/optional"
 	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
+	"go.uber.org/zap"
 )
 
 func (n *nifiClient) GetUsers() ([]nigoapi.UserEntity, error) {
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to get the users informations
 	usersEntity, rsp, body, err := client.TenantsApi.GetUsers(context)
 
-	if err := errorGetOperation(rsp, body, err); err != nil {
+	if err := errorGetOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -29,14 +30,14 @@ func (n *nifiClient) GetUser(id string) (*nigoapi.UserEntity, error) {
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to get the user informations
 	userEntity, rsp, body, err := client.TenantsApi.GetUser(context, id)
 
-	if err := errorGetOperation(rsp, body, err); err != nil {
+	if err := errorGetOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -47,13 +48,13 @@ func (n *nifiClient) CreateUser(entity nigoapi.UserEntity) (*nigoapi.UserEntity,
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to create the user
 	userEntity, rsp, body, err := client.TenantsApi.CreateUser(context, entity)
-	if err := errorCreateOperation(rsp, body, err); err != nil {
+	if err := errorCreateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -64,13 +65,13 @@ func (n *nifiClient) UpdateUser(entity nigoapi.UserEntity) (*nigoapi.UserEntity,
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to update the user
 	userEntity, rsp, body, err := client.TenantsApi.UpdateUser(context, entity.Id, entity)
-	if err := errorUpdateOperation(rsp, body, err); err != nil {
+	if err := errorUpdateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -81,7 +82,7 @@ func (n *nifiClient) RemoveUser(entity nigoapi.UserEntity) error {
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return ErrNoNodeClientsAvailable
 	}
 
@@ -91,5 +92,5 @@ func (n *nifiClient) RemoveUser(entity nigoapi.UserEntity) error {
 			Version: optional.NewString(strconv.FormatInt(*entity.Revision.Version, 10)),
 		})
 
-	return errorDeleteOperation(rsp, body, err)
+	return errorDeleteOperation(rsp, body, err, n.log)
 }

--- a/pkg/nificlient/usergroup.go
+++ b/pkg/nificlient/usergroup.go
@@ -5,20 +5,21 @@ import (
 
 	"github.com/antihax/optional"
 	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
+	"go.uber.org/zap"
 )
 
 func (n *nifiClient) GetUserGroups() ([]nigoapi.UserGroupEntity, error) {
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to get the user groups informations
 	userGroupsEntity, rsp, body, err := client.TenantsApi.GetUserGroups(context)
 
-	if err := errorGetOperation(rsp, body, err); err != nil {
+	if err := errorGetOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -29,14 +30,14 @@ func (n *nifiClient) GetUserGroup(id string) (*nigoapi.UserGroupEntity, error) {
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to get the user groups informations
 	userGroupEntity, rsp, body, err := client.TenantsApi.GetUserGroup(context, id)
 
-	if err := errorGetOperation(rsp, body, err); err != nil {
+	if err := errorGetOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -47,13 +48,13 @@ func (n *nifiClient) CreateUserGroup(entity nigoapi.UserGroupEntity) (*nigoapi.U
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to create the user group
 	userGroupEntity, rsp, body, err := client.TenantsApi.CreateUserGroup(context, entity)
-	if err := errorCreateOperation(rsp, body, err); err != nil {
+	if err := errorCreateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 	return &userGroupEntity, nil
@@ -63,13 +64,13 @@ func (n *nifiClient) UpdateUserGroup(entity nigoapi.UserGroupEntity) (*nigoapi.U
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to update the user group
 	userGroupEntity, rsp, body, err := client.TenantsApi.UpdateUserGroup(context, entity.Id, entity)
-	if err := errorUpdateOperation(rsp, body, err); err != nil {
+	if err := errorUpdateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -80,7 +81,7 @@ func (n *nifiClient) RemoveUserGroup(entity nigoapi.UserGroupEntity) error {
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return ErrNoNodeClientsAvailable
 	}
 
@@ -90,5 +91,5 @@ func (n *nifiClient) RemoveUserGroup(entity nigoapi.UserGroupEntity) error {
 			Version: optional.NewString(strconv.FormatInt(*entity.Revision.Version, 10)),
 		})
 
-	return errorDeleteOperation(rsp, body, err)
+	return errorDeleteOperation(rsp, body, err, n.log)
 }

--- a/pkg/nificlient/version.go
+++ b/pkg/nificlient/version.go
@@ -1,18 +1,21 @@
 package nificlient
 
-import nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
+import (
+	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
+	"go.uber.org/zap"
+)
 
 func (n *nifiClient) CreateVersionUpdateRequest(pgId string, entity nigoapi.VersionControlInformationEntity) (*nigoapi.VersionedFlowUpdateRequestEntity, error) {
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to create the version update request
 	request, rsp, body, err := client.VersionsApi.InitiateVersionControlUpdate(context, pgId, entity)
-	if err := errorUpdateOperation(rsp, body, err); err != nil {
+	if err := errorUpdateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -23,13 +26,13 @@ func (n *nifiClient) GetVersionUpdateRequest(id string) (*nigoapi.VersionedFlowU
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to get the update request information
 	request, rsp, body, err := client.VersionsApi.GetUpdateRequest(context, id)
-	if err := errorGetOperation(rsp, body, err); err != nil {
+	if err := errorGetOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -40,13 +43,13 @@ func (n *nifiClient) CreateVersionRevertRequest(pgId string, entity nigoapi.Vers
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to create the version revert request
 	request, rsp, body, err := client.VersionsApi.InitiateRevertFlowVersion(context, pgId, entity)
-	if err := errorUpdateOperation(rsp, body, err); err != nil {
+	if err := errorUpdateOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 
@@ -57,13 +60,13 @@ func (n *nifiClient) GetVersionRevertRequest(id string) (*nigoapi.VersionedFlowU
 	// Get nigoapi client, favoring the one associated to the coordinator node.
 	client, context := n.privilegeCoordinatorClient()
 	if client == nil {
-		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		n.log.Error("Error during creating node client", zap.Error(ErrNoNodeClientsAvailable))
 		return nil, ErrNoNodeClientsAvailable
 	}
 
 	// Request on Nifi Rest API to get the revert request information
 	request, rsp, body, err := client.VersionsApi.GetRevertRequest(context, id)
-	if err := errorGetOperation(rsp, body, err); err != nil {
+	if err := errorGetOperation(rsp, body, err, n.log); err != nil {
 		return nil, err
 	}
 

--- a/pkg/pki/certmanagerpki/certmanager_pki.go
+++ b/pkg/pki/certmanagerpki/certmanager_pki.go
@@ -21,7 +21,8 @@ import (
 )
 
 func (c *certManager) FinalizePKI(ctx context.Context, logger zap.Logger) error {
-	logger.Info("Removing cert-manager certificates and secrets")
+	logger.Info("Removing cert-manager certificates and secrets",
+		zap.String("clusterName", c.cluster.Name))
 
 	// Safety check that we are actually doing something
 	if c.cluster.Spec.ListenersConfig.SSLSecrets == nil {
@@ -79,7 +80,8 @@ func (c *certManager) FinalizePKI(ctx context.Context, logger zap.Logger) error 
 }
 
 func (c *certManager) ReconcilePKI(ctx context.Context, logger zap.Logger, scheme *runtime.Scheme, externalHostnames []string) (err error) {
-	logger.Info("Reconciling cert-manager PKI")
+	logger.Info("Reconciling cert-manager PKI",
+		zap.String("clusterName", c.cluster.Name))
 
 	resources, err := c.
 		nifipki(ctx, scheme, externalHostnames)

--- a/pkg/resources/nifi/nifi.go
+++ b/pkg/resources/nifi/nifi.go
@@ -91,7 +91,10 @@ func (r *Reconciler) Reconcile(log zap.Logger) error {
 	)
 
 	if r.NifiCluster.IsExternal() {
-		log.Debug("reconciled")
+		log.Debug("reconciled",
+			zap.String("component", componentName),
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.String("clusterNamespace", r.NifiCluster.Namespace))
 		return nil
 	}
 	// TODO : manage external LB
@@ -256,7 +259,10 @@ func (r *Reconciler) Reconcile(log zap.Logger) error {
 		}
 	}
 
-	log.Debug("reconciled")
+	log.Debug("reconciled",
+		zap.String("component", componentName),
+		zap.String("clusterName", r.NifiCluster.Name),
+		zap.String("clusterNamespace", r.NifiCluster.Namespace))
 
 	return nil
 }
@@ -315,7 +321,8 @@ OUTERLOOP:
 		for _, node := range deletedNodes {
 
 			if node.ObjectMeta.DeletionTimestamp != nil {
-				log.Info(fmt.Sprintf("Nopde %s is already on terminating state", node.Labels["nodeId"]))
+				log.Info("Node is already on terminating state",
+					zap.String("nodeId", node.Labels["nodeId"]))
 				continue
 			}
 
@@ -368,7 +375,8 @@ OUTERLOOP:
 					if err != nil {
 						if apierrors.IsNotFound(err) {
 							// can happen when node was not fully initialized and now is deleted
-							log.Info(fmt.Sprintf("PVC for Node %s not found. Continue", node.Labels["nodeId"]))
+							log.Info("PVC for Node not found. Continue",
+								zap.String("nodeId", node.Labels["nodeId"]))
 						}
 
 						return errors.WrapIfWithDetails(err, "could not delete pvc for node", "id", node.Labels["nodeId"])
@@ -397,7 +405,8 @@ func arePodsAlreadyDeleted(pods []corev1.Pod, log zap.Logger) bool {
 		if node.ObjectMeta.DeletionTimestamp == nil {
 			return false
 		}
-		log.Info(fmt.Sprintf("Node %s is already on terminating state", node.Labels["nodeId"]))
+		log.Info("Node is already on terminating state",
+			zap.String("nodeId", node.Labels["nodeId"]))
 	}
 	return true
 }
@@ -438,7 +447,6 @@ func (r *Reconciler) getServerAndClientDetails(nodeId int32) (string, string, []
 	return serverPass, clientPass, superUsers, nil
 }
 
-//
 func generateNodeIdsFromPodSlice(pods []corev1.Pod) []string {
 	ids := make([]string, len(pods))
 	for i, node := range pods {
@@ -450,7 +458,10 @@ func generateNodeIdsFromPodSlice(pods []corev1.Pod) []string {
 func (r *Reconciler) reconcileNifiPVC(log zap.Logger, desiredPVC *corev1.PersistentVolumeClaim) error {
 	var currentPVC = desiredPVC.DeepCopy()
 	desiredType := reflect.TypeOf(desiredPVC)
-	log.Debug("searching with label because name is empty", zap.String("kind", desiredType.String()))
+	log.Debug("searching for pvc with label because name is empty",
+		zap.String("nifiCluster", r.NifiCluster.Name),
+		zap.String("nodeId", desiredPVC.Labels["nodeId"]),
+		zap.String("kind", desiredType.String()))
 
 	pvcList := &corev1.PersistentVolumeClaimList{}
 	matchingLabels := client.MatchingLabels{
@@ -473,7 +484,10 @@ func (r *Reconciler) reconcileNifiPVC(log zap.Logger, desiredPVC *corev1.Persist
 		if err := r.Client.Create(context.TODO(), desiredPVC); err != nil {
 			return errorfactory.New(errorfactory.APIFailure{}, err, "creating resource failed", "kind", desiredType)
 		}
-		log.Info("resource created")
+		log.Info("Persistent volume created",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.String("pvcName", desiredPVC.Name),
+			zap.String("pvcNamespace", desiredPVC.Namespace))
 		return nil
 	}
 	alreadyCreated := false
@@ -514,7 +528,10 @@ func (r *Reconciler) reconcileNifiPVC(log zap.Logger, desiredPVC *corev1.Persist
 			if err := r.Client.Update(context.TODO(), desiredPVC); err != nil {
 				return errorfactory.New(errorfactory.APIFailure{}, err, "updating resource failed", "kind", desiredType)
 			}
-			log.Info("resource updated")
+			log.Debug("persistent volume updated",
+				zap.String("clusterName", r.NifiCluster.Name),
+				zap.String("pvcName", desiredPVC.Name),
+				zap.String("pvcNamespace", desiredPVC.Namespace))
 		}
 	}
 	return nil
@@ -528,7 +545,10 @@ func (r *Reconciler) reconcileNifiPod(log zap.Logger, desiredPod *corev1.Pod) (e
 	currentPod := desiredPod.DeepCopy()
 	desiredType := reflect.TypeOf(desiredPod)
 
-	log.Debug("searching with label because name is empty", zap.String("kind", desiredType.String()))
+	log.Debug("searching for pod with label because name is empty",
+		zap.String("clusterName", r.NifiCluster.Name),
+		zap.String("nodeId", desiredPod.Labels["nodeId"]),
+		zap.String("kind", desiredType.String()))
 
 	podList := &corev1.PodList{}
 	matchingLabels := client.MatchingLabels{
@@ -572,14 +592,20 @@ func (r *Reconciler) reconcileNifiPod(log zap.Logger, desiredPod *corev1.Pod) (e
 					statusErr, "could not update node graceful action state"), false
 			}
 		}
-		log.Info("resource created")
+		log.Info("Pod created",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.String("nodeId", desiredPod.Labels["nodeId"]),
+			zap.String("podName", desiredPod.Name))
+
 		return nil, false
 	} else if len(podList.Items) == 1 {
 		currentPod = podList.Items[0].DeepCopy()
 		nodeId := currentPod.Labels["nodeId"]
 		if _, ok := r.NifiCluster.Status.NodesState[nodeId]; ok {
 			if currentPod.Spec.NodeName == "" {
-				log.Info(fmt.Sprintf("pod for NodeId %s does not scheduled to node yet", nodeId))
+				log.Debug("pod for NodeId is not scheduled to node yet",
+					zap.String("clusterName", r.NifiCluster.Name),
+					zap.String("nodeId", nodeId))
 			}
 		} else {
 			return errorfactory.New(errorfactory.InternalError{}, errors.New("reconcile failed"),
@@ -590,9 +616,7 @@ func (r *Reconciler) reconcileNifiPod(log zap.Logger, desiredPod *corev1.Pod) (e
 			"more then one matching pod found", "labels", matchingLabels), false
 	}
 
-	// TODO check if this err == nil check necessary (baluchicken)
 	if err == nil {
-
 		// Since toleration does not support patchStrategy:"merge,retainKeys", we need to add all toleration from the current pod if the toleration is set in the CR
 		if len(desiredPod.Spec.Tolerations) > 0 {
 			desiredPod.Spec.Tolerations = append(desiredPod.Spec.Tolerations, currentPod.Spec.Tolerations...)
@@ -609,7 +633,10 @@ func (r *Reconciler) reconcileNifiPod(log zap.Logger, desiredPod *corev1.Pod) (e
 		// Check if the resource actually updated
 		patchResult, err := patch.DefaultPatchMaker.Calculate(currentPod, desiredPod)
 		if err != nil {
-			log.Error("could not match objects", zap.Error(err), zap.String("kind", desiredType.String()))
+			log.Error("could not match pod objects",
+				zap.String("clusterName", r.NifiCluster.Name),
+				zap.String("kind", desiredType.String()),
+				zap.Error(err))
 		} else if patchResult.IsEmpty() {
 			if !k8sutil.IsPodTerminatedOrShutdown(currentPod) &&
 				r.NifiCluster.Status.NodesState[currentPod.Labels["nodeId"]].ConfigurationState == v1alpha1.ConfigInSync {
@@ -626,7 +653,9 @@ func (r *Reconciler) reconcileNifiPod(log zap.Logger, desiredPod *corev1.Pod) (e
 					}
 				}
 
-				log.Debug("resource is in sync")
+				log.Debug("pod resource is in sync",
+					zap.String("clusterName", r.NifiCluster.Name),
+					zap.String("podName", desiredPod.Name))
 
 				return nil, k8sutil.PodReady(currentPod)
 			}
@@ -688,17 +717,6 @@ func (r *Reconciler) reconcileNifiPod(log zap.Logger, desiredPod *corev1.Pod) (e
 }
 
 func (r *Reconciler) reconcileNifiUsersAndGroups(log zap.Logger) error {
-	/*	nifiControllerName := fmt.Sprintf(
-			pkicommon.NodeControllerFQDNTemplate,
-			r.NifiCluster.GetNifiControllerUserIdentity(),
-			r.NifiCluster.Namespace,
-			r.NifiCluster.Spec.ListenersConfig.GetClusterDomain(),
-		)
-
-		if r.NifiCluster.Spec.ControllerUserIdentity != nil {
-			nifiControllerName = *r.NifiCluster.Spec.ControllerUserIdentity
-		}*/
-
 	controllerNamespacedName := types.NamespacedName{
 		Name: r.NifiCluster.GetNifiControllerUserIdentity(), Namespace: r.NifiCluster.Namespace}
 

--- a/pkg/resources/nifi/poddisruptionbudget.go
+++ b/pkg/resources/nifi/poddisruptionbudget.go
@@ -70,7 +70,10 @@ func (r *Reconciler) computeMinAvailable(log zap.Logger) (intstr.IntOrString, er
 	if strings.HasSuffix(disruptionBudget, "%") {
 		percentage, err := strconv.ParseFloat(disruptionBudget[:len(disruptionBudget)-1], 4)
 		if err != nil {
-			log.Error("error occured during parsing the disruption budget", zap.Error(err))
+			log.Error("error occured during parsing the disruption budget",
+				zap.String("clusterName", r.NifiCluster.Name),
+				zap.String("disruptionBudget", disruptionBudget),
+				zap.Error(err))
 			return intstr.FromInt(-1), err
 		} else {
 			budget = int(math.Floor((percentage * float64(nodes)) / 100))
@@ -79,7 +82,10 @@ func (r *Reconciler) computeMinAvailable(log zap.Logger) (intstr.IntOrString, er
 		// treat static number budget
 		staticBudget, err := strconv.ParseInt(disruptionBudget, 10, 0)
 		if err != nil {
-			log.Error("error occured during parsing the disruption budget", zap.Error(err))
+			log.Error("error occured during parsing the disruption budget",
+				zap.String("clusterName", r.NifiCluster.Name),
+				zap.String("disruptionBudget", disruptionBudget),
+				zap.Error(err))
 			return intstr.FromInt(-1), err
 		} else {
 			budget = int(staticBudget)

--- a/pkg/resources/nifi/secretconfig.go
+++ b/pkg/resources/nifi/secretconfig.go
@@ -84,18 +84,27 @@ func (r Reconciler) generateNifiPropertiesNodeConfig(id int32, nodeConfig *v1alp
 	}
 
 	if err := mergo.Merge(&readOnlyNodeConfig, readOnlyClusterConfig); err != nil {
-		log.Error("error occurred during merging readonly configs", zap.Error(err))
+		log.Error("error occurred during merging readonly configs",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Int32("nodeId", id),
+			zap.Error(err))
 	}
 
 	//Generate the Complete Configuration for the Node
 	completeConfigMap := map[string]string{}
 
 	if err := mergo.Merge(&completeConfigMap, readOnlyNodeConfig); err != nil {
-		log.Error("error occurred during merging readOnly config to complete configs", zap.Error(err))
+		log.Error("error occurred during merging readOnly config to complete configs",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Int32("nodeId", id),
+			zap.Error(err))
 	}
 
 	if err := mergo.Merge(&completeConfigMap, util.ParsePropertiesFormat(r.getNifiPropertiesConfigString(nodeConfig, id, serverPass, clientPass, superUsers, log))); err != nil {
-		log.Error("error occurred during merging operator generated configs", zap.Error(err))
+		log.Error("error occurred during merging operator generated configs",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Int32("nodeId", id),
+			zap.Error(err))
 	}
 
 	completeConfig := []string{}
@@ -110,7 +119,6 @@ func (r Reconciler) generateNifiPropertiesNodeConfig(id int32, nodeConfig *v1alp
 	return strings.Join(completeConfig, "\n")
 }
 
-//
 func (r *Reconciler) getNifiPropertiesConfigString(nConfig *v1alpha1.NodeConfig, id int32, serverPass, clientPass string, superUsers []string, log zap.Logger) string {
 
 	base := r.GetNifiPropertiesBase(id)
@@ -159,7 +167,10 @@ func (r *Reconciler) getNifiPropertiesConfigString(nConfig *v1alpha1.NodeConfig,
 		"ZookeeperConnectString": r.NifiCluster.Spec.ZKAddress,
 		"ZookeeperPath":          r.NifiCluster.Spec.GetZkPath(),
 	}); err != nil {
-		log.Error("error occurred during parsing the config template", zap.Error(err))
+		log.Error("error occurred during parsing the config template",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Int32("nodeId", id),
+			zap.Error(err))
 	}
 	return out.String()
 }
@@ -201,18 +212,27 @@ func (r Reconciler) generateZookeeperPropertiesNodeConfig(id int32, nodeConfig *
 	}
 
 	if err := mergo.Merge(&readOnlyNodeConfig, readOnlyClusterConfig); err != nil {
-		log.Error("error occurred during merging readonly configs", zap.Error(err))
+		log.Error("error occurred during merging readonly configs",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Int32("nodeId", id),
+			zap.Error(err))
 	}
 
 	//Generate the Complete Configuration for the Node
 	completeConfigMap := map[string]string{}
 
 	if err := mergo.Merge(&completeConfigMap, readOnlyNodeConfig); err != nil {
-		log.Error("error occurred during merging readOnly config to complete configs", zap.Error(err))
+		log.Error("error occurred during merging readOnly config to complete configs",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Int32("nodeId", id),
+			zap.Error(err))
 	}
 
 	if err := mergo.Merge(&completeConfigMap, util.ParsePropertiesFormat(r.getZookeeperPropertiesConfigString(nodeConfig, id, log))); err != nil {
-		log.Error("error occurred during merging operator generated configs", zap.Error(err))
+		log.Error("error occurred during merging operator generated configs",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Int32("nodeId", id),
+			zap.Error(err))
 	}
 
 	completeConfig := []string{}
@@ -240,7 +260,10 @@ func (r *Reconciler) getZookeeperPropertiesConfigString(nConfig *v1alpha1.NodeCo
 	var out bytes.Buffer
 	t := template.Must(template.New("nConfig-config").Parse(config.ZookeeperPropertiesTemplate))
 	if err := t.Execute(&out, map[string]interface{}{}); err != nil {
-		log.Error("error occurred during parsing the config template", zap.Error(err))
+		log.Error("error occurred during parsing the config template",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Int32("nodeId", id),
+			zap.Error(err))
 	}
 	return out.String()
 }
@@ -260,7 +283,10 @@ func (r *Reconciler) getStateManagementConfigString(nConfig *v1alpha1.NodeConfig
 		"ZookeeperConnectString": r.NifiCluster.Spec.ZKAddress,
 		"ZookeeperPath":          r.NifiCluster.Spec.GetZkPath(),
 	}); err != nil {
-		log.Error("error occurred during parsing the config template", zap.Error(err))
+		log.Error("error occurred during parsing the config template",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Int32("nodeId", id),
+			zap.Error(err))
 	}
 	return out.String()
 }
@@ -279,7 +305,10 @@ func (r *Reconciler) getLoginIdentityProvidersConfigString(nConfig *v1alpha1.Nod
 		"Id":                id,
 		"LdapConfiguration": r.NifiCluster.Spec.LdapConfiguration,
 	}); err != nil {
-		log.Error("error occurred during parsing the config template", zap.Error(err))
+		log.Error("error occurred during parsing the config template",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Int32("nodeId", id),
+			zap.Error(err))
 	}
 	return out.String()
 }
@@ -298,7 +327,10 @@ func (r *Reconciler) getLogbackConfigString(nConfig *v1alpha1.NodeConfig, id int
 				if err == nil {
 					return conf
 				}
-				log.Error("error occurred during getting readonly secret config", zap.Error(err))
+				log.Error("error occurred during getting readonly secret config",
+					zap.String("clusterName", r.NifiCluster.Name),
+					zap.Int32("nodeId", id),
+					zap.Error(err))
 			}
 
 			if node.ReadOnlyConfig.LogbackConfig.ReplaceConfigMap != nil {
@@ -306,7 +338,10 @@ func (r *Reconciler) getLogbackConfigString(nConfig *v1alpha1.NodeConfig, id int
 				if err == nil {
 					return conf
 				}
-				log.Error("error occurred during getting readonly configmap", zap.Error(err))
+				log.Error("error occurred during getting readonly configmap",
+					zap.String("clusterName", r.NifiCluster.Name),
+					zap.Int32("nodeId", id),
+					zap.Error(err))
 			}
 			break
 		}
@@ -317,7 +352,10 @@ func (r *Reconciler) getLogbackConfigString(nConfig *v1alpha1.NodeConfig, id int
 		if err == nil {
 			return conf
 		}
-		log.Error("error occurred during getting readonly secret config", zap.Error(err))
+		log.Error("error occurred during getting readonly secret config",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Int32("nodeId", id),
+			zap.Error(err))
 	}
 
 	if r.NifiCluster.Spec.ReadOnlyConfig.LogbackConfig.ReplaceConfigMap != nil {
@@ -325,7 +363,10 @@ func (r *Reconciler) getLogbackConfigString(nConfig *v1alpha1.NodeConfig, id int
 		if err == nil {
 			return conf
 		}
-		log.Error("error occurred during getting readonly configmap", zap.Error(err))
+		log.Error("error occurred during getting readonly configmap",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Int32("nodeId", id),
+			zap.Error(err))
 	}
 
 	var out bytes.Buffer
@@ -334,7 +375,10 @@ func (r *Reconciler) getLogbackConfigString(nConfig *v1alpha1.NodeConfig, id int
 		"NifiCluster": r.NifiCluster,
 		"Id":          id,
 	}); err != nil {
-		log.Error("error occurred during parsing the config template", zap.Error(err))
+		log.Error("error occurred during parsing the config template",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Int32("nodeId", id),
+			zap.Error(err))
 	}
 	return out.String()
 }
@@ -353,7 +397,10 @@ func (r *Reconciler) getBootstrapNotificationServicesConfigString(nConfig *v1alp
 				if err == nil {
 					return conf
 				}
-				log.Error("error occurred during getting readonly secret config", zap.Error(err))
+				log.Error("error occurred during getting bootstrap notification readonly secret config",
+					zap.String("clusterName", r.NifiCluster.Name),
+					zap.Int32("nodeId", id),
+					zap.Error(err))
 			}
 
 			if node.ReadOnlyConfig.BootstrapNotificationServicesReplaceConfig.ReplaceConfigMap != nil {
@@ -361,7 +408,10 @@ func (r *Reconciler) getBootstrapNotificationServicesConfigString(nConfig *v1alp
 				if err == nil {
 					return conf
 				}
-				log.Error("error occurred during getting readonly configmap", zap.Error(err))
+				log.Error("error occurred during getting bootstrap notification readonly configmap",
+					zap.String("clusterName", r.NifiCluster.Name),
+					zap.Int32("nodeId", id),
+					zap.Error(err))
 			}
 			break
 		}
@@ -372,7 +422,10 @@ func (r *Reconciler) getBootstrapNotificationServicesConfigString(nConfig *v1alp
 		if err == nil {
 			return conf
 		}
-		log.Error("error occurred during getting readonly secret config", zap.Error(err))
+		log.Error("error occurred during getting cluster bootstrap notification readonly secret config",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Int32("nodeId", id),
+			zap.Error(err))
 	}
 
 	if r.NifiCluster.Spec.ReadOnlyConfig.BootstrapNotificationServicesReplaceConfig.ReplaceConfigMap != nil {
@@ -380,7 +433,10 @@ func (r *Reconciler) getBootstrapNotificationServicesConfigString(nConfig *v1alp
 		if err == nil {
 			return conf
 		}
-		log.Error("error occurred during getting readonly configmap", zap.Error(err))
+		log.Error("error occurred during getting cluster bootstrap notification readonly configmap",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Int32("nodeId", id),
+			zap.Error(err))
 	}
 
 	var out bytes.Buffer
@@ -389,7 +445,10 @@ func (r *Reconciler) getBootstrapNotificationServicesConfigString(nConfig *v1alp
 		"NifiCluster": r.NifiCluster,
 		"Id":          id,
 	}); err != nil {
-		log.Error("error occurred during parsing the config template", zap.Error(err))
+		log.Error("error occurred during parsing the bootstrap notification config template",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Int32("nodeId", id),
+			zap.Error(err))
 	}
 	return out.String()
 }
@@ -413,7 +472,10 @@ func (r *Reconciler) getAuthorizersConfigString(nConfig *v1alpha1.NodeConfig, id
 			if err == nil {
 				authorizersTemplate = conf
 			}
-			log.Error("error occurred during getting authorizer readonly configmap", zap.Error(err))
+			log.Error("error occurred during getting authorizer readonly configmap",
+				zap.String("clusterName", r.NifiCluster.Name),
+				zap.Int32("nodeId", id),
+				zap.Error(err))
 		}
 
 		// The secret takes precedence over the ConfigMap, if it exists.
@@ -422,7 +484,10 @@ func (r *Reconciler) getAuthorizersConfigString(nConfig *v1alpha1.NodeConfig, id
 			if err == nil {
 				authorizersTemplate = conf
 			}
-			log.Error("error occurred during getting authorizer readonly secret config", zap.Error(err))
+			log.Error("error occurred during getting authorizer readonly secret config",
+				zap.String("clusterName", r.NifiCluster.Name),
+				zap.Int32("nodeId", id),
+				zap.Error(err))
 		}
 
 		for nId, nodeState := range r.NifiCluster.Status.NodesState {
@@ -454,7 +519,10 @@ func (r *Reconciler) getAuthorizersConfigString(nConfig *v1alpha1.NodeConfig, id
 		"NodeList":       nodeList,
 		"ControllerUser": r.NifiCluster.GetNifiControllerUserIdentity(),
 	}); err != nil {
-		log.Error("error occurred during parsing the config template", zap.Error(err))
+		log.Error("error occurred during parsing the config template",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Int32("nodeId", id),
+			zap.Error(err))
 	}
 
 	return out.String()
@@ -490,18 +558,27 @@ func (r Reconciler) generateBootstrapPropertiesNodeConfig(id int32, nodeConfig *
 	}
 
 	if err := mergo.Merge(&readOnlyNodeConfig, readOnlyClusterConfig); err != nil {
-		log.Error("error occurred during merging readonly configs", zap.Error(err))
+		log.Error("error occurred during merging readonly configs",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Int32("nodeId", id),
+			zap.Error(err))
 	}
 
 	//Generate the Complete Configuration for the Node
 	completeConfigMap := map[string]string{}
 
 	if err := mergo.Merge(&completeConfigMap, readOnlyNodeConfig); err != nil {
-		log.Error("error occurred during merging readOnly config to complete configs", zap.Error(err))
+		log.Error("error occurred during merging readOnly config to complete configs",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Int32("nodeId", id),
+			zap.Error(err))
 	}
 
 	if err := mergo.Merge(&completeConfigMap, util.ParsePropertiesFormat(r.getBootstrapPropertiesConfigString(nodeConfig, id, log))); err != nil {
-		log.Error("error occurred during merging operator generated configs", zap.Error(err))
+		log.Error("error occurred during merging operator generated configs",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Int32("nodeId", id),
+			zap.Error(err))
 	}
 
 	completeConfig := []string{}
@@ -532,7 +609,10 @@ func (r *Reconciler) getBootstrapPropertiesConfigString(nConfig *v1alpha1.NodeCo
 		"Id":          id,
 		"JvmMemory":   base.GetNifiJvmMemory(),
 	}); err != nil {
-		log.Error("error occurred during parsing the config template", zap.Error(err))
+		log.Error("error occurred during parsing the config template",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Int32("nodeId", id),
+			zap.Error(err))
 	}
 	return out.String()
 }
@@ -590,7 +670,9 @@ func (r Reconciler) generateReadOnlyConfig(
 	if overrideSecretConfig != nil {
 		secretConfig, err := r.getSecrectConfig(context.TODO(), *overrideSecretConfig)
 		if err != nil {
-			log.Error("error occurred during getting readonly secret config", zap.Error(err))
+			log.Error("error occurred during getting readonly secret config",
+				zap.String("clusterName", r.NifiCluster.Name),
+				zap.Error(err))
 		}
 		parsedReadOnlySecretClusterConfig = util.ParsePropertiesFormat(secretConfig)
 	}
@@ -598,7 +680,9 @@ func (r Reconciler) generateReadOnlyConfig(
 	if overrideConfigMap != nil {
 		configMap, err := r.getConfigMap(context.TODO(), *overrideConfigMap)
 		if err != nil {
-			log.Error("error occurred during getting readonly configmap", zap.Error(err))
+			log.Error("error occurred during getting readonly configmap",
+				zap.String("clusterName", r.NifiCluster.Name),
+				zap.Error(err))
 		}
 		parsedReadOnlyClusterConfigMap = util.ParsePropertiesFormat(configMap)
 	}
@@ -606,14 +690,20 @@ func (r Reconciler) generateReadOnlyConfig(
 	parsedReadOnlyClusterConfig = util.ParsePropertiesFormat(overrideConfigs)
 
 	if err := mergo.Merge(readOnlyClusterConfig, parsedReadOnlySecretClusterConfig); err != nil {
-		log.Error("error occurred during merging readonly configs", zap.Error(err))
+		log.Error("error occurred during merging readonly configs",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Error(err))
 	}
 
 	if err := mergo.Merge(readOnlyClusterConfig, parsedReadOnlyClusterConfig); err != nil {
-		log.Error("error occurred during merging readonly configs", zap.Error(err))
+		log.Error("error occurred during merging readonly configs",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Error(err))
 	}
 
 	if err := mergo.Merge(readOnlyClusterConfig, parsedReadOnlyClusterConfigMap); err != nil {
-		log.Error("error occurred during merging readonly configs", zap.Error(err))
+		log.Error("error occurred during merging readonly configs",
+			zap.String("clusterName", r.NifiCluster.Name),
+			zap.Error(err))
 	}
 }

--- a/pkg/resources/nifi/service.go
+++ b/pkg/resources/nifi/service.go
@@ -45,7 +45,9 @@ func (r *Reconciler) externalServices(log zap.Logger) []runtimeClient.Object {
 
 		annotations := &eService.Metadata.Annotations
 		if err := mergo.Merge(annotations, r.NifiCluster.Spec.Service.Annotations); err != nil {
-			log.Error("error occurred during merging service annotations", zap.Error(err))
+			log.Error("error occurred during merging service annotations",
+				zap.String("clusterName", r.NifiCluster.Name),
+				zap.Error(err))
 		}
 
 		usedPorts := r.generateServicePortForExternalListeners(eService)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | partially #109
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This PR aims to begin refactoring nifikop logging to be much less verbose and more informational. Specifically, I attempted to do all of the following in this PR:

- Convert all `log.Info(fmt.Sprintf("..."))` occurrences to `log.Info("...", zap.String("...", var))`
- Add as much context as possible to each log message. For example, which `NifiCluster` the log is in relation to, `nodeId`, k8s object name or namespace, etc.
- Set default log level to Info
- Drop common logs that aren't crucial to be aware of to debug level

I've identified several other areas that warrant refactoring to clean up logs, but will leave these for later PRs to keep PR scope small.

For example, the below link refers to this `RequeueWithError()` method, which is called 500+ times as a result of an error but it logs all of the error messages at the `Info` level. There's no context for what the error was, so it's not possible to know what context should be added to the log. Callers right now provide a parameter that's formatted with `fmt.Sprintf("...")`, but we can make use of the zap lib to consistently log errors. Callers should log the context for the error and then requeue the request. 

https://github.com/konpyutaika/nifikop/blob/v0.11.0-release/controllers/controller_common.go#L24-L28

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

This is a part of a larger effort to increase the quality of logs generated by nifikop.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
