### PR TITLE
use name of storageConfig in k8s PVC resource name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 - [PR #115](https://github.com/konpyutaika/nifikop/pull/115) - **[Operator]** Upgrade go version to 1.18.
+- [PR #122](https://github.com/konpyutaika/nifikop/pull/122) - **[Operator/NifiCluster]** Change name of PVCs that nifikop creates to include the name set via `NifiCluster.Spec.node_config_group.StorageConfigs.Name`
 
 ### Deprecated
 

--- a/pkg/resources/nifi/pvc.go
+++ b/pkg/resources/nifi/pvc.go
@@ -19,9 +19,9 @@ func (r *Reconciler) pvc(id int32, storage v1alpha1.StorageConfig, log zap.Logge
 			util.MergeLabels(
 				nifiutil.LabelsForNifi(r.NifiCluster.Name),
 				map[string]string{
-						"nodeId": fmt.Sprintf("%d", id),
-						"storageName": storage.Name,
-					},
+					"nodeId":      fmt.Sprintf("%d", id),
+					"storageName": storage.Name,
+				},
 			),
 			map[string]string{"mountPath": storage.MountPath, "storageName": storage.Name}, r.NifiCluster),
 		Spec: *storage.PVCSpec,

--- a/pkg/resources/nifi/pvc.go
+++ b/pkg/resources/nifi/pvc.go
@@ -15,10 +15,13 @@ import (
 func (r *Reconciler) pvc(id int32, storage v1alpha1.StorageConfig, log zap.Logger) runtime.Object {
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: templates.ObjectMetaWithGeneratedNameAndAnnotations(
-			fmt.Sprintf(templates.NodeStorageTemplate, r.NifiCluster.Name, id),
+			fmt.Sprintf(templates.NodeStorageTemplate, r.NifiCluster.Name, id, storage.Name),
 			util.MergeLabels(
 				nifiutil.LabelsForNifi(r.NifiCluster.Name),
-				map[string]string{"nodeId": fmt.Sprintf("%d", id)},
+				map[string]string{
+						"nodeId": fmt.Sprintf("%d", id),
+						"storageName": storage.Name,
+					},
 			),
 			map[string]string{"mountPath": storage.MountPath, "storageName": storage.Name}, r.NifiCluster),
 		Spec: *storage.PVCSpec,

--- a/pkg/resources/templates/variables.go
+++ b/pkg/resources/templates/variables.go
@@ -2,6 +2,6 @@ package templates
 
 const (
 	NodeConfigTemplate            = "%s-config"
-	NodeStorageTemplate           = "%s-%d-storage"
+	NodeStorageTemplate           = "%s-%d-%s-storage-"
 	ExternalClusterSecretTemplate = "%s-basic-secret"
 )


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Adds the PVC name specified in the `NifiCluster.Spec.StorageConfigs.Name` to the name of the k8s `PersistentVolumeClaim` so they're more easily identified. It also adds the name to the PVC metadata labels.

Additionally, I fixed a bug where the PVC `generateName` config didn't end in a hyphen so PVCs have a name that resembles `my-nifi-1-storagew7frb` instead of `my-nifi-1-storage-w7frb`.

With this PR, the PVC names will now look like `my-nifi-1-content-repo-storage-w7frb` if the `NifiCluster.Spec.StorageConfigs.Name` is `content-repo`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To more easily identify what each persistent volume claim is used for. This is useful when building Grafana dashboards monitoring persistent volumes.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
