### PR TITLE
Adding nifi.sensitive.props.key to all config samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 - [PR #115](https://github.com/konpyutaika/nifikop/pull/115) - **[Operator]** Upgrade go version to 1.18.
+- [PR #123](https://github.com/konpyutaika/nifikop/pull/123) - **[Documentation]** Added nifi.sensitive.props.key to config samples
 
 ### Deprecated
 

--- a/config/samples/nifi_v1alpha1_nificluster.yaml
+++ b/config/samples/nifi_v1alpha1_nificluster.yaml
@@ -99,6 +99,7 @@ spec:
       #	on template, configurations and overrideConfigMap
       overrideConfigs: |
         nifi.ui.banner.text=NiFiKop
+        nifi.sensitive.props.key=thisIsABadSensitiveKeyPassword
       # A comma separated list of allowed HTTP Host header values to consider when NiFi
       # is running securely and will be receiving requests to a different host[:port] than it is bound to.
       # https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#web-properties

--- a/config/samples/simplenificluster.yaml
+++ b/config/samples/simplenificluster.yaml
@@ -22,6 +22,10 @@ spec:
   clusterImage: "apache/nifi:1.15.3"
   initContainerImage: 'busybox:1.34.0'
   oneNifiNodePerNode: true
+  readOnlyConfig:
+    nifiProperties:
+      overrideConfigs: |
+        nifi.sensitive.props.key=thisIsABadSensitiveKeyPassword
   pod:
     labels:
       cluster-name: simplenifi

--- a/config/samples/tls_secured_nificluster.yaml
+++ b/config/samples/tls_secured_nificluster.yaml
@@ -26,6 +26,7 @@ spec:
       # Additionnals nifi.properties configuration that will override the one produced based
       # on template and configurations.
       overrideConfigs: |
+        nifi.sensitive.props.key=thisIsABadSensitiveKeyPassword
         nifi.security.user.oidc.discovery.url=https://accounts.google.com/.well-known/openid-configuration
         nifi.security.user.oidc.client.id=930711295780-i72an91pqj7rib88r23qfv5q7mth8hgv.apps.googleusercontent.com
         nifi.security.user.oidc.client.secret=BvmEyr81P0YXZtIt1FIfGsRs


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
From apache/nifi:1.14.0, the `nifi.sensitive.props.key` in `nifi.properties` is mandatory.

To fix the sample YAMLs in `config/samples/` I've added an override so they can used out of the box

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
This was an optional field in <1.13.0, so is not a breaking change if users try to deploy a lower version

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
