### PR TITLE
minor additional reduction in high volume logs

### DIFF
--- a/controllers/nificluster_controller.go
+++ b/controllers/nificluster_controller.go
@@ -168,7 +168,7 @@ func (r *NifiClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 	}
 
-	r.Log.Info("ensuring finalizers on nificluster", zap.String("clusterName", instance.Name))
+	r.Log.Debug("ensuring finalizers on nificluster", zap.String("clusterName", instance.Name))
 	if instance, err = r.ensureFinalizers(ctx, instance); err != nil {
 		return RequeueWithError(r.Log, "failed to ensure finalizers on nificluster instance "+instance.Name, err)
 	}

--- a/pkg/clientwrappers/reportingtask/reportingtask.go
+++ b/pkg/clientwrappers/reportingtask/reportingtask.go
@@ -10,6 +10,7 @@ import (
 	"github.com/konpyutaika/nifikop/pkg/errorfactory"
 	"github.com/konpyutaika/nifikop/pkg/nificlient"
 	"github.com/konpyutaika/nifikop/pkg/util/clientconfig"
+	"go.uber.org/zap"
 )
 
 var log = common.CustomLogger().Named("reportingtask-method")
@@ -108,6 +109,8 @@ func SyncReportingTask(config *clientconfig.NifiConfig, cluster *v1alpha1.NifiCl
 	}
 
 	if entity.Status.RunStatus == "STOPPED" || entity.Status.RunStatus == "DISABLED" {
+		log.Info("Starting Prometheus reporting task",
+			zap.String("clusterName", cluster.Name))
 		entity, err = nClient.UpdateRunStatusReportingTask(entity.Id, nigoapi.ReportingTaskRunStatusEntity{
 			Revision: entity.Revision,
 			State:    "RUNNING",

--- a/pkg/k8sutil/status.go
+++ b/pkg/k8sutil/status.go
@@ -249,7 +249,9 @@ func UpdateRootProcessGroupIdStatus(c client.Client, cluster *v1alpha1.NifiClust
 	}
 	// update loses the typeMeta of the config that's used later when setting ownerrefs
 	cluster.TypeMeta = typeMeta
-	logger.Info("Root process group id updated", zap.String("id", id))
+	logger.Debug("Root process group id updated", 
+		zap.String("clusterName", cluster.Name),
+		zap.String("id", id))
 	return nil
 }
 

--- a/pkg/resources/nifi/nifi.go
+++ b/pkg/resources/nifi/nifi.go
@@ -259,7 +259,7 @@ func (r *Reconciler) Reconcile(log zap.Logger) error {
 		}
 	}
 
-	log.Debug("reconciled",
+	log.Info("Successfully reconciled cluster",
 		zap.String("component", componentName),
 		zap.String("clusterName", r.NifiCluster.Name),
 		zap.String("clusterNamespace", r.NifiCluster.Namespace))


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | partially #109 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This further reduces some logs which are unnecessarily high volume. Unfortunately, until #119 is resolved some logs will remain high volume, such as the "Successfully reconciled cluster" log. That is left as-is so it's at least known that a cluster was completely and successfully reconciled.

Since this falls under the same category as #121 , i won't update the changelog.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
