### PR TITLE
fix(nifikop): only use prefix of hostname in comparison during node d…

### DIFF
--- a/config/crd/bases/nifi.konpyutaika.com_nificlusters.yaml
+++ b/config/crd/bases/nifi.konpyutaika.com_nificlusters.yaml
@@ -1,9 +1,10 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: nificlusters.nifi.konpyutaika.com
 spec:
@@ -1987,12 +1988,12 @@ spec:
                               before the pod starts, and deleted when the pod is removed.
                               \n Use this if: a) the volume is only needed while the
                               pod runs, b) features of normal volumes like restoring
-                              from snapshot or capacity tracking are needed, c) the
-                              storage driver is specified through a storage class,
+                              from snapshot or capacity    tracking are needed, c)
+                              the storage driver is specified through a storage class,
                               and d) the storage driver supports dynamic volume provisioning
-                              through a PersistentVolumeClaim (see EphemeralVolumeSource
-                              for more information on the connection between this
-                              volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim
+                              through    a PersistentVolumeClaim (see EphemeralVolumeSource
+                              for more    information on the connection between this
+                              volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim
                               or one of the vendor-specific APIs for volumes that
                               persist for longer than the lifecycle of an individual
                               pod. \n Use CSI for light-weight local ephemeral volumes
@@ -2096,13 +2097,13 @@ spec:
                                           the other is non-empty. There are two important
                                           differences between DataSource and DataSourceRef:
                                           * While DataSource only allows two specific
-                                          types of objects, DataSourceRef allows any
-                                          non-core object, as well as PersistentVolumeClaim
+                                          types of objects, DataSourceRef   allows
+                                          any non-core object, as well as PersistentVolumeClaim
                                           objects. * While DataSource ignores disallowed
-                                          values (dropping them), DataSourceRef preserves
+                                          values (dropping them), DataSourceRef   preserves
                                           all values, and generates an error if a
-                                          disallowed value is specified. (Alpha) Using
-                                          this field requires the AnyVolumeDataSource
+                                          disallowed value is   specified. (Alpha)
+                                          Using this field requires the AnyVolumeDataSource
                                           feature gate to be enabled.'
                                         properties:
                                           apiGroup:
@@ -3191,8 +3192,8 @@ spec:
                         type: object
                       type: array
                     image:
-                      description: Docker image used by the operator to create the
-                        node associated https://hub.docker.com/r/apache/nifi/
+                      description: ' Docker image used by the operator to create the
+                        node associated  https://hub.docker.com/r/apache/nifi/'
                       type: string
                     imagePullPolicy:
                       description: imagePullPolicy define the pull policy for NiFi
@@ -3560,13 +3561,13 @@ spec:
                                   automatically if one of them is empty and the other
                                   is non-empty. There are two important differences
                                   between DataSource and DataSourceRef: * While DataSource
-                                  only allows two specific types of objects, DataSourceRef
-                                  allows any non-core object, as well as PersistentVolumeClaim
+                                  only allows two specific types of objects, DataSourceRef   allows
+                                  any non-core object, as well as PersistentVolumeClaim
                                   objects. * While DataSource ignores disallowed values
-                                  (dropping them), DataSourceRef preserves all values,
-                                  and generates an error if a disallowed value is
-                                  specified. (Alpha) Using this field requires the
-                                  AnyVolumeDataSource feature gate to be enabled.'
+                                  (dropping them), DataSourceRef   preserves all values,
+                                  and generates an error if a disallowed value is   specified.
+                                  (Alpha) Using this field requires the AnyVolumeDataSource
+                                  feature gate to be enabled.'
                                 properties:
                                   apiGroup:
                                     description: APIGroup is the group for the resource
@@ -4187,19 +4188,20 @@ spec:
                                   when the pod is removed. \n Use this if: a) the
                                   volume is only needed while the pod runs, b) features
                                   of normal volumes like restoring from snapshot or
-                                  capacity tracking are needed, c) the storage driver
-                                  is specified through a storage class, and d) the
-                                  storage driver supports dynamic volume provisioning
-                                  through a PersistentVolumeClaim (see EphemeralVolumeSource
-                                  for more information on the connection between this
-                                  volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                  or one of the vendor-specific APIs for volumes that
-                                  persist for longer than the lifecycle of an individual
-                                  pod. \n Use CSI for light-weight local ephemeral
-                                  volumes if the CSI driver is meant to be used that
-                                  way - see the documentation of the driver for more
-                                  information. \n A pod can use both types of ephemeral
-                                  volumes and persistent volumes at the same time."
+                                  capacity    tracking are needed, c) the storage
+                                  driver is specified through a storage class, and
+                                  d) the storage driver supports dynamic volume provisioning
+                                  through    a PersistentVolumeClaim (see EphemeralVolumeSource
+                                  for more    information on the connection between
+                                  this volume type    and PersistentVolumeClaim).
+                                  \n Use PersistentVolumeClaim or one of the vendor-specific
+                                  APIs for volumes that persist for longer than the
+                                  lifecycle of an individual pod. \n Use CSI for light-weight
+                                  local ephemeral volumes if the CSI driver is meant
+                                  to be used that way - see the documentation of the
+                                  driver for more information. \n A pod can use both
+                                  types of ephemeral volumes and persistent volumes
+                                  at the same time."
                                 properties:
                                   volumeClaimTemplate:
                                     description: "Will be used to create a stand-alone
@@ -4301,15 +4303,14 @@ spec:
                                               is non-empty. There are two important
                                               differences between DataSource and DataSourceRef:
                                               * While DataSource only allows two specific
-                                              types of objects, DataSourceRef allows
+                                              types of objects, DataSourceRef   allows
                                               any non-core object, as well as PersistentVolumeClaim
                                               objects. * While DataSource ignores
-                                              disallowed values (dropping them), DataSourceRef
-                                              preserves all values, and generates
-                                              an error if a disallowed value is specified.
-                                              (Alpha) Using this field requires the
-                                              AnyVolumeDataSource feature gate to
-                                              be enabled.'
+                                              disallowed values (dropping them), DataSourceRef   preserves
+                                              all values, and generates an error if
+                                              a disallowed value is   specified. (Alpha)
+                                              Using this field requires the AnyVolumeDataSource
+                                              feature gate to be enabled.'
                                             properties:
                                               apiGroup:
                                                 description: APIGroup is the group
@@ -5448,8 +5449,8 @@ spec:
                             type: object
                           type: array
                         image:
-                          description: Docker image used by the operator to create
-                            the node associated https://hub.docker.com/r/apache/nifi/
+                          description: ' Docker image used by the operator to create
+                            the node associated  https://hub.docker.com/r/apache/nifi/'
                           type: string
                         imagePullPolicy:
                           description: imagePullPolicy define the pull policy for
@@ -5832,12 +5833,12 @@ spec:
                                       is empty and the other is non-empty. There are
                                       two important differences between DataSource
                                       and DataSourceRef: * While DataSource only allows
-                                      two specific types of objects, DataSourceRef
-                                      allows any non-core object, as well as PersistentVolumeClaim
+                                      two specific types of objects, DataSourceRef   allows
+                                      any non-core object, as well as PersistentVolumeClaim
                                       objects. * While DataSource ignores disallowed
-                                      values (dropping them), DataSourceRef preserves
+                                      values (dropping them), DataSourceRef   preserves
                                       all values, and generates an error if a disallowed
-                                      value is specified. (Alpha) Using this field
+                                      value is   specified. (Alpha) Using this field
                                       requires the AnyVolumeDataSource feature gate
                                       to be enabled.'
                                     properties:
@@ -8286,10 +8287,10 @@ spec:
                       description: 'WhenUnsatisfiable indicates how to deal with a
                         pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
                         (default) tells the scheduler not to schedule it. - ScheduleAnyway
-                        tells the scheduler to schedule the pod in any location, but
+                        tells the scheduler to schedule the pod in any location,   but
                         giving higher precedence to topologies that would help reduce
-                        the skew. A constraint is considered "Unsatisfiable" for an
-                        incoming pod if and only if every possible node assignment
+                        the   skew. A constraint is considered "Unsatisfiable" for
+                        an incoming pod if and only if every possible node assignment
                         for that pod would violate "MaxSkew" on some topology. For
                         example, in a 3-zone cluster, MaxSkew is set to 1, and pods
                         with the same labelSelector spread as 3/1/1: | zone1 | zone2

--- a/config/crd/bases/nifi.konpyutaika.com_nifidataflows.yaml
+++ b/config/crd/bases/nifi.konpyutaika.com_nifidataflows.yaml
@@ -1,9 +1,10 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: nifidataflows.nifi.konpyutaika.com
 spec:

--- a/config/crd/bases/nifi.konpyutaika.com_nifiparametercontexts.yaml
+++ b/config/crd/bases/nifi.konpyutaika.com_nifiparametercontexts.yaml
@@ -1,9 +1,10 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: nifiparametercontexts.nifi.konpyutaika.com
 spec:

--- a/config/crd/bases/nifi.konpyutaika.com_nifiregistryclients.yaml
+++ b/config/crd/bases/nifi.konpyutaika.com_nifiregistryclients.yaml
@@ -1,9 +1,10 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: nifiregistryclients.nifi.konpyutaika.com
 spec:

--- a/config/crd/bases/nifi.konpyutaika.com_nifiusergroups.yaml
+++ b/config/crd/bases/nifi.konpyutaika.com_nifiusergroups.yaml
@@ -1,9 +1,10 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: nifiusergroups.nifi.konpyutaika.com
 spec:

--- a/config/crd/bases/nifi.konpyutaika.com_nifiusers.yaml
+++ b/config/crd/bases/nifi.konpyutaika.com_nifiusers.yaml
@@ -1,9 +1,10 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: nifiusers.nifi.konpyutaika.com
 spec:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/helm/nifikop/crds/nifi.konpyutaika.com_nificlusters.yaml
+++ b/helm/nifikop/crds/nifi.konpyutaika.com_nificlusters.yaml
@@ -1,9 +1,10 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: nificlusters.nifi.konpyutaika.com
 spec:
@@ -1987,12 +1988,12 @@ spec:
                               before the pod starts, and deleted when the pod is removed.
                               \n Use this if: a) the volume is only needed while the
                               pod runs, b) features of normal volumes like restoring
-                              from snapshot or capacity tracking are needed, c) the
-                              storage driver is specified through a storage class,
+                              from snapshot or capacity    tracking are needed, c)
+                              the storage driver is specified through a storage class,
                               and d) the storage driver supports dynamic volume provisioning
-                              through a PersistentVolumeClaim (see EphemeralVolumeSource
-                              for more information on the connection between this
-                              volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim
+                              through    a PersistentVolumeClaim (see EphemeralVolumeSource
+                              for more    information on the connection between this
+                              volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim
                               or one of the vendor-specific APIs for volumes that
                               persist for longer than the lifecycle of an individual
                               pod. \n Use CSI for light-weight local ephemeral volumes
@@ -2096,13 +2097,13 @@ spec:
                                           the other is non-empty. There are two important
                                           differences between DataSource and DataSourceRef:
                                           * While DataSource only allows two specific
-                                          types of objects, DataSourceRef allows any
-                                          non-core object, as well as PersistentVolumeClaim
+                                          types of objects, DataSourceRef   allows
+                                          any non-core object, as well as PersistentVolumeClaim
                                           objects. * While DataSource ignores disallowed
-                                          values (dropping them), DataSourceRef preserves
+                                          values (dropping them), DataSourceRef   preserves
                                           all values, and generates an error if a
-                                          disallowed value is specified. (Alpha) Using
-                                          this field requires the AnyVolumeDataSource
+                                          disallowed value is   specified. (Alpha)
+                                          Using this field requires the AnyVolumeDataSource
                                           feature gate to be enabled.'
                                         properties:
                                           apiGroup:
@@ -3191,8 +3192,8 @@ spec:
                         type: object
                       type: array
                     image:
-                      description: Docker image used by the operator to create the
-                        node associated https://hub.docker.com/r/apache/nifi/
+                      description: ' Docker image used by the operator to create the
+                        node associated  https://hub.docker.com/r/apache/nifi/'
                       type: string
                     imagePullPolicy:
                       description: imagePullPolicy define the pull policy for NiFi
@@ -3560,13 +3561,13 @@ spec:
                                   automatically if one of them is empty and the other
                                   is non-empty. There are two important differences
                                   between DataSource and DataSourceRef: * While DataSource
-                                  only allows two specific types of objects, DataSourceRef
-                                  allows any non-core object, as well as PersistentVolumeClaim
+                                  only allows two specific types of objects, DataSourceRef   allows
+                                  any non-core object, as well as PersistentVolumeClaim
                                   objects. * While DataSource ignores disallowed values
-                                  (dropping them), DataSourceRef preserves all values,
-                                  and generates an error if a disallowed value is
-                                  specified. (Alpha) Using this field requires the
-                                  AnyVolumeDataSource feature gate to be enabled.'
+                                  (dropping them), DataSourceRef   preserves all values,
+                                  and generates an error if a disallowed value is   specified.
+                                  (Alpha) Using this field requires the AnyVolumeDataSource
+                                  feature gate to be enabled.'
                                 properties:
                                   apiGroup:
                                     description: APIGroup is the group for the resource
@@ -4187,19 +4188,20 @@ spec:
                                   when the pod is removed. \n Use this if: a) the
                                   volume is only needed while the pod runs, b) features
                                   of normal volumes like restoring from snapshot or
-                                  capacity tracking are needed, c) the storage driver
-                                  is specified through a storage class, and d) the
-                                  storage driver supports dynamic volume provisioning
-                                  through a PersistentVolumeClaim (see EphemeralVolumeSource
-                                  for more information on the connection between this
-                                  volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                  or one of the vendor-specific APIs for volumes that
-                                  persist for longer than the lifecycle of an individual
-                                  pod. \n Use CSI for light-weight local ephemeral
-                                  volumes if the CSI driver is meant to be used that
-                                  way - see the documentation of the driver for more
-                                  information. \n A pod can use both types of ephemeral
-                                  volumes and persistent volumes at the same time."
+                                  capacity    tracking are needed, c) the storage
+                                  driver is specified through a storage class, and
+                                  d) the storage driver supports dynamic volume provisioning
+                                  through    a PersistentVolumeClaim (see EphemeralVolumeSource
+                                  for more    information on the connection between
+                                  this volume type    and PersistentVolumeClaim).
+                                  \n Use PersistentVolumeClaim or one of the vendor-specific
+                                  APIs for volumes that persist for longer than the
+                                  lifecycle of an individual pod. \n Use CSI for light-weight
+                                  local ephemeral volumes if the CSI driver is meant
+                                  to be used that way - see the documentation of the
+                                  driver for more information. \n A pod can use both
+                                  types of ephemeral volumes and persistent volumes
+                                  at the same time."
                                 properties:
                                   volumeClaimTemplate:
                                     description: "Will be used to create a stand-alone
@@ -4301,15 +4303,14 @@ spec:
                                               is non-empty. There are two important
                                               differences between DataSource and DataSourceRef:
                                               * While DataSource only allows two specific
-                                              types of objects, DataSourceRef allows
+                                              types of objects, DataSourceRef   allows
                                               any non-core object, as well as PersistentVolumeClaim
                                               objects. * While DataSource ignores
-                                              disallowed values (dropping them), DataSourceRef
-                                              preserves all values, and generates
-                                              an error if a disallowed value is specified.
-                                              (Alpha) Using this field requires the
-                                              AnyVolumeDataSource feature gate to
-                                              be enabled.'
+                                              disallowed values (dropping them), DataSourceRef   preserves
+                                              all values, and generates an error if
+                                              a disallowed value is   specified. (Alpha)
+                                              Using this field requires the AnyVolumeDataSource
+                                              feature gate to be enabled.'
                                             properties:
                                               apiGroup:
                                                 description: APIGroup is the group
@@ -5448,8 +5449,8 @@ spec:
                             type: object
                           type: array
                         image:
-                          description: Docker image used by the operator to create
-                            the node associated https://hub.docker.com/r/apache/nifi/
+                          description: ' Docker image used by the operator to create
+                            the node associated  https://hub.docker.com/r/apache/nifi/'
                           type: string
                         imagePullPolicy:
                           description: imagePullPolicy define the pull policy for
@@ -5832,12 +5833,12 @@ spec:
                                       is empty and the other is non-empty. There are
                                       two important differences between DataSource
                                       and DataSourceRef: * While DataSource only allows
-                                      two specific types of objects, DataSourceRef
-                                      allows any non-core object, as well as PersistentVolumeClaim
+                                      two specific types of objects, DataSourceRef   allows
+                                      any non-core object, as well as PersistentVolumeClaim
                                       objects. * While DataSource ignores disallowed
-                                      values (dropping them), DataSourceRef preserves
+                                      values (dropping them), DataSourceRef   preserves
                                       all values, and generates an error if a disallowed
-                                      value is specified. (Alpha) Using this field
+                                      value is   specified. (Alpha) Using this field
                                       requires the AnyVolumeDataSource feature gate
                                       to be enabled.'
                                     properties:
@@ -8286,10 +8287,10 @@ spec:
                       description: 'WhenUnsatisfiable indicates how to deal with a
                         pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
                         (default) tells the scheduler not to schedule it. - ScheduleAnyway
-                        tells the scheduler to schedule the pod in any location, but
+                        tells the scheduler to schedule the pod in any location,   but
                         giving higher precedence to topologies that would help reduce
-                        the skew. A constraint is considered "Unsatisfiable" for an
-                        incoming pod if and only if every possible node assignment
+                        the   skew. A constraint is considered "Unsatisfiable" for
+                        an incoming pod if and only if every possible node assignment
                         for that pod would violate "MaxSkew" on some topology. For
                         example, in a 3-zone cluster, MaxSkew is set to 1, and pods
                         with the same labelSelector spread as 3/1/1: | zone1 | zone2

--- a/helm/nifikop/crds/nifi.konpyutaika.com_nifidataflows.yaml
+++ b/helm/nifikop/crds/nifi.konpyutaika.com_nifidataflows.yaml
@@ -1,9 +1,10 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: nifidataflows.nifi.konpyutaika.com
 spec:

--- a/helm/nifikop/crds/nifi.konpyutaika.com_nifiparametercontexts.yaml
+++ b/helm/nifikop/crds/nifi.konpyutaika.com_nifiparametercontexts.yaml
@@ -1,9 +1,10 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: nifiparametercontexts.nifi.konpyutaika.com
 spec:

--- a/helm/nifikop/crds/nifi.konpyutaika.com_nifiregistryclients.yaml
+++ b/helm/nifikop/crds/nifi.konpyutaika.com_nifiregistryclients.yaml
@@ -1,9 +1,10 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: nifiregistryclients.nifi.konpyutaika.com
 spec:

--- a/helm/nifikop/crds/nifi.konpyutaika.com_nifiusergroups.yaml
+++ b/helm/nifikop/crds/nifi.konpyutaika.com_nifiusergroups.yaml
@@ -1,9 +1,10 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: nifiusergroups.nifi.konpyutaika.com
 spec:

--- a/helm/nifikop/crds/nifi.konpyutaika.com_nifiusers.yaml
+++ b/helm/nifikop/crds/nifi.konpyutaika.com_nifiusers.yaml
@@ -1,9 +1,10 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: nifiusers.nifi.konpyutaika.com
 spec:

--- a/pkg/nificlient/client.go
+++ b/pkg/nificlient/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"emperror.dev/errors"
@@ -349,7 +350,7 @@ func (n *nifiClient) nodeDtoByNodeId(nId int32) *nigoapi.NodeDto {
 	for id := range n.nodes {
 		nodeDto := n.nodes[id]
 		// Check if the Cluster Node uri match with the one associated to the NifiCluster nodeId searched
-		if fmt.Sprintf("%s:%d", nodeDto.Address, nodeDto.ApiPort) == fmt.Sprintf(n.opts.NodeURITemplate, nId) {
+		if strings.Split(nodeDto.Address, ".")[0] == strings.Split(fmt.Sprintf(n.opts.NodeURITemplate, nId), ".")[0] {
 			return &nodeDto
 		}
 	}


### PR DESCRIPTION
…to search

The previous comparison was failing when headless mode was disabled, because the actual NiFi
node's address would include the 'all-nodes' service, but this comparison was expecting it
not to be included.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested
- [ ] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)
- [ ] Append changelog with changes

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here