### PR TITLE
Draft: fix(nifikop): only use prefix of hostname in node DTO comparison

### DIFF
--- a/pkg/nificlient/client.go
+++ b/pkg/nificlient/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"emperror.dev/errors"
@@ -349,7 +350,7 @@ func (n *nifiClient) nodeDtoByNodeId(nId int32) *nigoapi.NodeDto {
 	for id := range n.nodes {
 		nodeDto := n.nodes[id]
 		// Check if the Cluster Node uri match with the one associated to the NifiCluster nodeId searched
-		if fmt.Sprintf("%s:%d", nodeDto.Address, nodeDto.ApiPort) == fmt.Sprintf(n.opts.NodeURITemplate, nId) {
+		if strings.Split(nodeDto.Address, ".")[0] == strings.Split(fmt.Sprintf(n.opts.NodeURITemplate, nId), ".")[0] {
 			return &nodeDto
 		}
 	}


### PR DESCRIPTION
With headless mode disabled, this comparison would always fail because we are still using the "all-nodes" service root when we create the NiFi pod, so the address that comes back from the API is of the form `{node}.{all-nodes-svc}.{ns}.{cluster domain}`. This comparison was looking for the "all nodes" service _not_ to be used when headless mode was disabled, but that's not how nifikop currently functions. This root service is always used, headless or not.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested
- [ ] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)
- [ ] Append changelog with changes

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here