### PR TITLE
Update sync logic of dataflow to stop it fully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- [PR #136](https://github.com/konpyutaika/nifikop/pull/136) - **[Operator]** Update sync logic of dataflow to stop it fully.
 - [PR #115](https://github.com/konpyutaika/nifikop/pull/115) - **[Operator]** Upgrade go version to 1.18.
 - [PR #120](https://github.com/konpyutaika/nifikop/pull/120) - **[Operator]** Upgrade operator-sdk to v1.22.1.
 - [PR #121](https://github.com/konpyutaika/nifikop/pull/121) - **[Operator]** Refactor much of the nifikop logging to include more context.

--- a/pkg/clientwrappers/dataflow/dataflow.go
+++ b/pkg/clientwrappers/dataflow/dataflow.go
@@ -359,6 +359,10 @@ func SyncDataflow(
 			return status, err
 		}
 		flow.Status = *status
+
+		if err := UnscheduleDataflow(flow, config); err != nil {
+			return &flow.Status, err
+		}
 	}
 
 	pGEntity, err = nClient.GetProcessGroup(flow.Status.ProcessGroupID)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Feature to stop dataflow fully before syncing it.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To match new NiFi behavior since 1.16.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes