### PR TITLE
Removing instances where reconcile requeue didn't honor the interval time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - [PR #142](https://github.com/konpyutaika/nifikop/pull/142) - **[Operator]** Fixed issue where operator would modify `NifiCluster` and `NifiDataflow` status on every reconciliation loop unnecessarily.
 - [PR #151](https://github.com/konpyutaika/nifikop/pull/151) - **[Operator]** Fixed an issue where the controller logging erroneously appeared to all come from the same controller.
 
+### Fixed Bugs
+- [PR #155](https://github.com/konpyutaika/nifikop/pull/155) - **[Operator]** Removed instances where reconcile requeue didn't honor the interval time
+
 ### Deprecated
 
 ### Removed

--- a/controllers/nificluster_controller.go
+++ b/controllers/nificluster_controller.go
@@ -101,9 +101,7 @@ func (r *NifiClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	if instance.IsExternal() {
-		return reconcile.Result{
-			RequeueAfter: time.Duration(15) * time.Second,
-		}, nil
+		return RequeueAfter(time.Duration(15) * time.Second)
 	}
 	//
 	if len(instance.Status.State) == 0 || instance.Status.State == v1alpha1.NifiClusterInitializing {
@@ -138,32 +136,20 @@ func (r *NifiClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			switch errors.Cause(err).(type) {
 			case errorfactory.NodesUnreachable:
 				r.Log.Info("Nodes unreachable, may still be starting up", zap.String("reason", err.Error()))
-				return reconcile.Result{
-					RequeueAfter: intervalNotReady,
-				}, nil
+				return RequeueAfter(intervalNotReady)
 			case errorfactory.NodesNotReady:
 				r.Log.Info("Nodes not ready, may still be starting up", zap.String("reason", err.Error()))
-				return reconcile.Result{
-					RequeueAfter: intervalNotReady,
-				}, nil
+				return RequeueAfter(intervalNotReady)
 			case errorfactory.ResourceNotReady:
 				r.Log.Info("A new resource was not found or may not be ready", zap.String("reason", err.Error()))
-				return reconcile.Result{
-					RequeueAfter: intervalNotReady,
-				}, nil
+				return RequeueAfter(intervalNotReady)
 			case errorfactory.ReconcileRollingUpgrade:
 				r.Log.Info("Rolling Upgrade in Progress", zap.String("reason", err.Error()))
-				return reconcile.Result{
-					RequeueAfter: intervalRunning,
-				}, nil
+				return RequeueAfter(intervalRunning)
 			case errorfactory.NifiClusterNotReady:
-				return reconcile.Result{
-					RequeueAfter: intervalNotReady,
-				}, nil
+				return RequeueAfter(intervalNotReady)
 			case errorfactory.NifiClusterTaskRunning:
-				return reconcile.Result{
-					RequeueAfter: intervalRunning,
-				}, nil
+				return RequeueAfter(intervalRunning)
 			default:
 				return RequeueWithError(r.Log, err.Error(), err)
 			}
@@ -306,7 +292,7 @@ func (r *NifiClusterReconciler) checkFinalizers(ctx context.Context,
 		return RequeueWithError(r.Log, "failed to remove main finalizer from NifiCluser "+cluster.Name, err)
 	}
 
-	return reconcile.Result{}, nil
+	return Reconciled()
 }
 
 func (r *NifiClusterReconciler) removeFinalizer(ctx context.Context, cluster *v1alpha1.NifiCluster,

--- a/controllers/nificluster_controller.go
+++ b/controllers/nificluster_controller.go
@@ -149,7 +149,7 @@ func (r *NifiClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			case errorfactory.ResourceNotReady:
 				r.Log.Info("A new resource was not found or may not be ready", zap.String("reason", err.Error()))
 				return reconcile.Result{
-					RequeueAfter: intervalNotReady / 2,
+					RequeueAfter: intervalNotReady,
 				}, nil
 			case errorfactory.ReconcileRollingUpgrade:
 				r.Log.Info("Rolling Upgrade in Progress", zap.String("reason", err.Error()))
@@ -278,7 +278,7 @@ func (r *NifiClusterReconciler) checkFinalizers(ctx context.Context,
 
 		// Do any necessary PKI cleanup - a PKI backend should make sure any
 		// user finalizations are done before it does its final cleanup
-		interval := util.GetRequeueInterval(r.RequeueIntervals["CLUSTER_TASK_NOT_READY_REQUEUE_INTERVAL"]/3, r.RequeueOffset)
+		interval := util.GetRequeueInterval(r.RequeueIntervals["CLUSTER_TASK_NOT_READY_REQUEUE_INTERVAL"], r.RequeueOffset)
 		r.Log.Info("Tearing down any PKI resources for the nificluster",
 			zap.String("clusterName", cluster.Name))
 		if err = pki.GetPKIManager(r.Client, cluster).FinalizePKI(ctx, r.Log); err != nil {

--- a/controllers/nificlustertask_controller.go
+++ b/controllers/nificlustertask_controller.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -98,18 +97,11 @@ func (r *NifiClusterTaskReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if err != nil {
 		switch errors.Cause(err).(type) {
 		case errorfactory.NifiClusterNotReady, errorfactory.ResourceNotReady:
-			return reconcile.Result{
-				RequeueAfter: intervalNotReady,
-			}, nil
+			return RequeueAfter(intervalNotReady)
 		case errorfactory.NifiClusterTaskRunning:
-			return reconcile.Result{
-				RequeueAfter: intervalRunning,
-			}, nil
+			return RequeueAfter(intervalRunning)
 		case errorfactory.NifiClusterTaskTimeout, errorfactory.NifiClusterTaskFailure:
-
-			return reconcile.Result{
-				RequeueAfter: intervalTimeout,
-			}, nil
+			return RequeueAfter(intervalTimeout)
 		default:
 			return RequeueWithError(r.Log, err.Error(), err)
 		}
@@ -135,17 +127,11 @@ func (r *NifiClusterTaskReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if err != nil {
 		switch errors.Cause(err).(type) {
 		case errorfactory.NifiClusterNotReady:
-			return reconcile.Result{
-				RequeueAfter: intervalNotReady,
-			}, nil
+			return RequeueAfter(intervalNotReady)
 		case errorfactory.NifiClusterTaskRunning:
-			return reconcile.Result{
-				RequeueAfter: intervalRunning,
-			}, nil
+			return RequeueAfter(intervalRunning)
 		case errorfactory.NifiClusterTaskTimeout, errorfactory.NifiClusterTaskFailure:
-			return reconcile.Result{
-				RequeueAfter: intervalTimeout,
-			}, nil
+			return RequeueAfter(intervalTimeout)
 		default:
 			return RequeueWithError(r.Log, err.Error(), err)
 		}

--- a/controllers/nifidataflow_controller.go
+++ b/controllers/nifidataflow_controller.go
@@ -363,7 +363,7 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				errorfactory.NifiFlowControllerServiceScheduling,
 				errorfactory.NifiFlowScheduling, errorfactory.NifiFlowSyncing:
 				return reconcile.Result{
-					RequeueAfter: interval / 3,
+					RequeueAfter: interval,
 				}, nil
 			default:
 				r.Recorder.Event(instance, corev1.EventTypeWarning, "SynchronizingFailed",
@@ -418,7 +418,7 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if err := dataflow.ScheduleDataflow(instance, clientConfig); err != nil {
 			switch errors.Cause(err).(type) {
 			case errorfactory.NifiFlowControllerServiceScheduling, errorfactory.NifiFlowScheduling:
-				return RequeueAfter(interval / 3)
+				return RequeueAfter(interval)
 			default:
 				r.Recorder.Event(instance, corev1.EventTypeWarning, "StartingFailed",
 					fmt.Sprintf("Starting dataflow %s based on flow {bucketId : %s, flowId: %s, version: %s} failed.",
@@ -468,7 +468,7 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return Reconciled()
 	}
 
-	return RequeueAfter(interval / 3)
+	return RequeueAfter(interval)
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -515,7 +515,7 @@ func (r *NifiDataflowReconciler) checkFinalizers(ctx context.Context, flow *v1al
 		if err = r.finalizeNifiDataflow(flow, config); err != nil {
 			switch errors.Cause(err).(type) {
 			case errorfactory.NifiConnectionDropping, errorfactory.NifiFlowDraining:
-				return RequeueAfter(util.GetRequeueInterval(r.RequeueInterval/3, r.RequeueOffset))
+				return RequeueAfter(util.GetRequeueInterval(r.RequeueInterval, r.RequeueOffset))
 			default:
 				return RequeueWithError(r.Log, "failed to finalize NiFiDataflow "+flow.Name, err)
 			}

--- a/controllers/nifidataflow_controller.go
+++ b/controllers/nifidataflow_controller.go
@@ -362,9 +362,7 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				errorfactory.NifiFlowDraining,
 				errorfactory.NifiFlowControllerServiceScheduling,
 				errorfactory.NifiFlowScheduling, errorfactory.NifiFlowSyncing:
-				return reconcile.Result{
-					RequeueAfter: interval,
-				}, nil
+				return RequeueAfter(interval)
 			default:
 				r.Recorder.Event(instance, corev1.EventTypeWarning, "SynchronizingFailed",
 					fmt.Sprintf("Syncing dataflow %s based on flow {bucketId : %s, flowId: %s, version: %s} failed",

--- a/controllers/nifinodegroupautoscaler_controller.go
+++ b/controllers/nifinodegroupautoscaler_controller.go
@@ -169,9 +169,7 @@ func (r *NifiNodeGroupAutoscalerReconciler) Reconcile(ctx context.Context, req c
 		return RequeueWithError(r.Log, fmt.Sprintf("Failed to update node group autoscaler replica status for node group %s", nodeGroupAutoscaler.Spec.NodeConfigGroupId), err)
 	}
 
-	return reconcile.Result{
-		RequeueAfter: util.GetRequeueInterval(r.RequeueInterval, r.RequeueOffset),
-	}, nil
+	return RequeueAfter(util.GetRequeueInterval(r.RequeueInterval, r.RequeueOffset))
 }
 
 // scaleUp updates the provided cluster.Spec.Nodes list with the appropriate numNodesToAdd according to the autoscaler.Spec.UpscaleStrategy

--- a/controllers/nifiparametercontext_controller.go
+++ b/controllers/nifiparametercontext_controller.go
@@ -277,7 +277,7 @@ func (r *NifiParameterContextReconciler) Reconcile(ctx context.Context, req ctrl
 	if err != nil {
 		switch errors.Cause(err).(type) {
 		case errorfactory.NifiParameterContextUpdateRequestRunning:
-			return RequeueAfter(interval / 3)
+			return RequeueAfter(interval)
 		default:
 			r.Recorder.Event(instance, corev1.EventTypeNormal, "SynchronizingFailed",
 				fmt.Sprintf("Synchronizing parameter context %s failed", instance.Name))

--- a/controllers/nifiregistryclient_controller.go
+++ b/controllers/nifiregistryclient_controller.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"time"
 
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
 	"github.com/konpyutaika/nifikop/pkg/clientwrappers/registryclient"
@@ -132,7 +131,7 @@ func (r *NifiRegistryClientReconciler) Reconcile(ctx context.Context, req ctrl.R
 			if err := r.Client.Update(ctx, current); err != nil {
 				return RequeueWithError(r.Log, "failed to update NifiRegistryClient "+instance.Name, err)
 			}
-			return RequeueAfter(time.Duration(15) * time.Second)
+			return RequeueAfter(interval)
 		}
 
 		r.Recorder.Event(instance, corev1.EventTypeWarning, "ReferenceClusterError",

--- a/controllers/nifiuser_controller.go
+++ b/controllers/nifiuser_controller.go
@@ -198,7 +198,7 @@ func (r *NifiUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 				return ctrl.Result{
 					Requeue:      true,
-					RequeueAfter: interval / 3,
+					RequeueAfter: interval,
 				}, nil
 			case errorfactory.FatalReconcileError:
 				// TODO: (tinyzimmer) - Sleep for longer for now to give user time to see the error

--- a/controllers/nifiusergroup_controller.go
+++ b/controllers/nifiusergroup_controller.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"time"
 
 	"emperror.dev/errors"
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
@@ -171,7 +170,7 @@ func (r *NifiUserGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			if err := r.Client.Update(ctx, current); err != nil {
 				return RequeueWithError(r.Log, "failed to update NifiUserGroup "+instance.Name, err)
 			}
-			return RequeueAfter(time.Duration(15) * time.Second)
+			return RequeueAfter(interval)
 		}
 
 		r.Recorder.Event(instance, corev1.EventTypeWarning, "ReferenceClusterError",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | [Mentioned in PR 142](https://github.com/konpyutaika/nifikop/pull/142#issuecomment-1226880572)
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
There were instances where the reconcile requeue didn't honor the configured interval. I've removed these to bring it in line with all other reconcile requeues

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
