### PR TITLE
fix: jwt-go cve

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ require (
 	emperror.dev/errors v0.4.2
 	github.com/antihax/optional v1.0.0
 	github.com/banzaicloud/k8s-objectmatcher v1.4.1
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/erdrix/nigoapi v0.0.0-20211122092449-0fa36e567288
 	github.com/go-logr/logr v1.2.2
 	github.com/go-logr/zapr v1.2.3
+	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/imdario/mergo v0.3.12
 	github.com/jarcoal/httpmock v1.0.6
 	github.com/jetstack/cert-manager v1.7.2

--- a/go.sum
+++ b/go.sum
@@ -280,6 +280,9 @@ github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/pkg/nificlient/config/basic/basic_config.go
+++ b/pkg/nificlient/config/basic/basic_config.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"emperror.dev/errors"
-	"github.com/dgrijalva/jwt-go"
 	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
+	"github.com/golang-jwt/jwt"
 	"github.com/konpyutaika/nifikop/api/v1alpha1"
 	"github.com/konpyutaika/nifikop/pkg/common"
 	"github.com/konpyutaika/nifikop/pkg/errorfactory"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/konpyutaika/nifikop/issues/176
| License         | Apache 2.0


### What's in this PR?
Fixes a CVE in the jwt-go library by replacing it with golang-jwt

### Why?
To fix CVE


### Additional context


### Checklist
- [x] Implementation tested
- [ ] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)
- [ ] Append changelog with changes