### PR TITLE
remove OIDC client id and secret references

### DIFF
--- a/config/samples/override_secret.yaml
+++ b/config/samples/override_secret.yaml
@@ -5,5 +5,5 @@ metadata:
 apiVersion: v1
 data:
   nifi.properties: |
-    nifi.security.user.oidc.client.id=yourOIDCClientId
-    nifi.security.user.oidc.client.secret=yourOIDCClientSecret
+    nifi.security.user.oidc.client.id=<oidc client's id>
+    nifi.security.user.oidc.client.secret=<oidc client's secret>

--- a/config/samples/tls_secured_nificluster.yaml
+++ b/config/samples/tls_secured_nificluster.yaml
@@ -28,8 +28,8 @@ spec:
       overrideConfigs: |
         nifi.sensitive.props.key=thisIsABadSensitiveKeyPassword
         nifi.security.user.oidc.discovery.url=https://accounts.google.com/.well-known/openid-configuration
-        nifi.security.user.oidc.client.id=yourOIDCClientId
-        nifi.security.user.oidc.client.secret=yourOIDCClientSecret
+        nifi.security.user.oidc.client.id=<oidc client's id>
+        nifi.security.user.oidc.client.secret=<oidc client's secret>
         nifi.security.identity.mapping.pattern.dn=CN=([^,]*)(?:, (?:O|OU)=.*)?
         nifi.security.identity.mapping.value.dn=$1
         nifi.security.identity.mapping.transform.dn=NONE

--- a/docs/tutorials/secured_nifi_cluster_on_gcp_with_external_dns/kubernetes/nifi/secured_nifi_cluster.yaml
+++ b/docs/tutorials/secured_nifi_cluster_on_gcp_with_external_dns/kubernetes/nifi/secured_nifi_cluster.yaml
@@ -27,8 +27,8 @@ spec:
       # on template and configurations.
       overrideConfigs: |
         nifi.security.user.oidc.discovery.url=https://accounts.google.com/.well-known/openid-configuration
-        nifi.security.user.oidc.client.id=yourOIDCClientId
-        nifi.security.user.oidc.client.secret=yourOIDCClientSecret
+        nifi.security.user.oidc.client.id=<oidc client's id>
+        nifi.security.user.oidc.client.secret=<oidc client's secret>
         nifi.security.identity.mapping.pattern.dn=CN=([^,]*)(?:, (?:O|OU)=.*)?
         nifi.security.identity.mapping.value.dn=$1
         nifi.security.identity.mapping.transform.dn=NONE


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixes Git Guardian warnings since it detects either legitimate or real looking OIDC client Id and/or client secrets.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested
- [ ] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)
- [ ] Append changelog with changes
