### PR TITLE
change default metrics port to 9090 to avoid conflict with health probe port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed Bugs
 
+- [PR #195](https://github.com/konpyutaika/nifikop/pull/195) - **[Helm Chart]** Fixed bug where default metrics port collided with default health probe port.
+
 ### Deprecated
 
 ### Removed

--- a/helm/nifikop/values.yaml
+++ b/helm/nifikop/values.yaml
@@ -49,7 +49,7 @@ serviceAccount:
 metrics:
   ## if true deploy service for metrics access
   enabled: false
-  port: 8081
+  port: 9090
 
 logLevel: Info
 logEncoding: json

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 	var probeAddr string
 	var certManagerEnabled bool
 
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":9090", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #194 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Changes the default metrics port to 9090 so it doesn't conflict with the default health probe port.

This long-standing bug was actually uncovered by #188.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Otherwise, nifikop installed via helm won't work unless `metrics.port` is overridden to something other than `8081`.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

https://konpytika.slack.com/archives/C035X6KP684/p1666877790599529

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
