### PR TITLE
fix issue where certs get re-created immediately after deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed Bugs
 
 - [PR #195](https://github.com/konpyutaika/nifikop/pull/195) - **[Helm Chart]** Fixed bug where default metrics port collided with default health probe port.
+- [PR #210](https://github.com/konpyutaika/nifikop/pull/210) - **[NifiUser]** Fixed issue where `NifiUser` `Certificate` and `Secret` resources get re-created after the `NifiUser` has been marked for deletion and removed. This is most noticeable when deploying NiFi clusters via ArgoCD.
 
 ### Deprecated
 

--- a/controllers/nifiuser_controller.go
+++ b/controllers/nifiuser_controller.go
@@ -173,60 +173,61 @@ func (r *NifiUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 		pkiManager := pki.GetPKIManager(r.Client, cluster)
 
-		// check if marked for deletion
+		// check if marked for deletion. Otherwise, reconcile the certificate
 		if k8sutil.IsMarkedForDeletion(instance.ObjectMeta) {
 			r.Log.Info("Nifi user is marked for deletion, revoking certificates and removing finalizers.",
 				zap.String("user", instance.Name))
 			if err = pkiManager.FinalizeUserCertificate(ctx, instance); err != nil {
 				return RequeueWithError(r.Log, "failed to finalize certificate for user "+instance.Name, err)
 			}
-		}
+		} else {
 
-		r.Recorder.Event(instance, corev1.EventTypeNormal, "ReconcilingCertificate",
-			fmt.Sprintf("Reconciling certificate for nifi user %s", instance.Name))
-		// Reconcile no matter what to get a user certificate instance for ACL management
-		// TODO (tinyzimmer): This can go wrong if the user made a mistake in their secret path
-		// using the vault backend, then tried to delete and fix it. Should probably
-		// have the PKIManager export a GetUserCertificate specifically for deletions
-		// that will allow the error to fall through if the certificate doesn't exist.
-		_, err := pkiManager.ReconcileUserCertificate(ctx, instance, r.Scheme)
-		if err != nil {
-			switch errors.Cause(err).(type) {
-			case errorfactory.ResourceNotReady:
-				r.Log.Debug("generated secret not found, may not be ready",
-					zap.String("user", instance.Name))
+			r.Recorder.Event(instance, corev1.EventTypeNormal, "ReconcilingCertificate",
+				fmt.Sprintf("Reconciling certificate for nifi user %s", instance.Name))
+			// Reconcile no matter what to get a user certificate instance for ACL management
+			// TODO (tinyzimmer): This can go wrong if the user made a mistake in their secret path
+			// using the vault backend, then tried to delete and fix it. Should probably
+			// have the PKIManager export a GetUserCertificate specifically for deletions
+			// that will allow the error to fall through if the certificate doesn't exist.
+			_, err := pkiManager.ReconcileUserCertificate(ctx, instance, r.Scheme)
+			if err != nil {
+				switch errors.Cause(err).(type) {
+				case errorfactory.ResourceNotReady:
+					r.Log.Debug("generated secret not found, may not be ready",
+						zap.String("user", instance.Name))
 
-				return ctrl.Result{
-					Requeue:      true,
-					RequeueAfter: interval,
-				}, nil
-			case errorfactory.FatalReconcileError:
-				// TODO: (tinyzimmer) - Sleep for longer for now to give user time to see the error
-				// But really we should catch these kinds of issues in a pre-admission hook in a future PR
-				// The user can fix while this is looping and it will pick it up next reconcile attempt
-				r.Log.Error("Fatal error attempting to reconcile the user certificate. If using vault perhaps a permissions issue or improperly configured PKI?",
-					zap.String("user", instance.Name),
-					zap.Error(err))
-				return ctrl.Result{
-					Requeue:      true,
-					RequeueAfter: interval,
-				}, nil
-			case errorfactory.VaultAPIFailure:
-				// Same as above in terms of things that could be checked pre-flight on the cluster
-				r.Log.Error("Vault API error attempting to reconcile the user certificate. If using vault perhaps a permissions issue or improperly configured PKI?",
-					zap.String("user", instance.Name),
-					zap.Error(err))
-				return ctrl.Result{
-					Requeue:      true,
-					RequeueAfter: interval,
-				}, nil
-			default:
-				return RequeueWithError(r.Log, "failed to reconcile secret for user "+instance.Name, err)
+					return ctrl.Result{
+						Requeue:      true,
+						RequeueAfter: interval,
+					}, nil
+				case errorfactory.FatalReconcileError:
+					// TODO: (tinyzimmer) - Sleep for longer for now to give user time to see the error
+					// But really we should catch these kinds of issues in a pre-admission hook in a future PR
+					// The user can fix while this is looping and it will pick it up next reconcile attempt
+					r.Log.Error("Fatal error attempting to reconcile the user certificate. If using vault perhaps a permissions issue or improperly configured PKI?",
+						zap.String("user", instance.Name),
+						zap.Error(err))
+					return ctrl.Result{
+						Requeue:      true,
+						RequeueAfter: interval,
+					}, nil
+				case errorfactory.VaultAPIFailure:
+					// Same as above in terms of things that could be checked pre-flight on the cluster
+					r.Log.Error("Vault API error attempting to reconcile the user certificate. If using vault perhaps a permissions issue or improperly configured PKI?",
+						zap.String("user", instance.Name),
+						zap.Error(err))
+					return ctrl.Result{
+						Requeue:      true,
+						RequeueAfter: interval,
+					}, nil
+				default:
+					return RequeueWithError(r.Log, "failed to reconcile secret for user "+instance.Name, err)
+				}
 			}
-		}
 
-		r.Recorder.Event(instance, corev1.EventTypeNormal, "ReconciledCertificate",
-			fmt.Sprintf("Reconciled certificate for nifi user %s", instance.Name))
+			r.Recorder.Event(instance, corev1.EventTypeNormal, "ReconciledCertificate",
+				fmt.Sprintf("Reconciled certificate for nifi user %s", instance.Name))
+		}
 	}
 
 	// Generate the client configuration.
@@ -435,5 +436,4 @@ func (r *NifiUserReconciler) addFinalizer(user *v1alpha1.NifiUser) {
 	r.Log.Debug("Adding Finalizer for the NifiUser",
 		zap.String("user", user.Name))
 	user.SetFinalizers(append(user.GetFinalizers(), userFinalizer))
-	return
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #209 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

The nifi user controller hits a condition where a `NifiUser` is marked for deletion and the controller revokes certs and deletes secrets. However, it then immediately reconciles the certs & secrets again which re-creates them. The code which does this is [here](https://github.com/konpyutaika/nifikop/blob/master/controllers/nifiuser_controller.go#L176-L229). This causes `NifiCluster` deletions in ArgoCD to hang and not delete cleanly because the operator is re-creating resources that had just been deleted.

I tested this by deploying a `NifiCluster` via ArgoCD. Once it came all the way up & certs had been generated, I deleted the cluster in ArgoCD. Prior to this change, the deletion would get hung up on Certificates/Secrets that the operator re-created. With this change, clusters are gracefully deleted by ArgoCD and re-created.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To correctly reconcile resources associated with `NifiUser` objects.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
