### PR TITLE
Patch infinite request searching

### DIFF
--- a/api/v1/nifidataflow_types.go
+++ b/api/v1/nifidataflow_types.go
@@ -62,7 +62,7 @@ type UpdateRequest struct {
 	// the state of the request
 	State string `json:"state"`
 	// whether or not this request was found.
-	NotFound bool `json:"notFound"`
+	NotFound bool `json:"notFound,omitempty"`
 }
 
 type DropRequest struct {
@@ -101,7 +101,7 @@ type DropRequest struct {
 	// the state of the request
 	State string `json:"state"`
 	// whether or not this request was found.
-	NotFound bool `json:"notFound"`
+	NotFound bool `json:"notFound,omitempty"`
 }
 
 // NifiDataflowStatus defines the observed state of NifiDataflow

--- a/api/v1/nifidataflow_types.go
+++ b/api/v1/nifidataflow_types.go
@@ -61,6 +61,8 @@ type UpdateRequest struct {
 	PercentCompleted int32 `json:"percentCompleted"`
 	// the state of the request
 	State string `json:"state"`
+	// whether or not this request was found.
+	NotFound bool `json:"notFound"`
 }
 
 type DropRequest struct {
@@ -98,6 +100,8 @@ type DropRequest struct {
 	Dropped string `json:"dropped"`
 	// the state of the request
 	State string `json:"state"`
+	// whether or not this request was found.
+	NotFound bool `json:"notFound"`
 }
 
 // NifiDataflowStatus defines the observed state of NifiDataflow

--- a/api/v1/nifiparametercontext_types.go
+++ b/api/v1/nifiparametercontext_types.go
@@ -62,7 +62,7 @@ type ParameterContextUpdateRequest struct {
 	// the state of the request.
 	State string `json:"state"`
 	// whether or not this request was found.
-	NotFound bool `json:"notFound"`
+	NotFound bool `json:"notFound,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1/nifiparametercontext_types.go
+++ b/api/v1/nifiparametercontext_types.go
@@ -61,6 +61,8 @@ type ParameterContextUpdateRequest struct {
 	PercentCompleted int32 `json:"percentCompleted"`
 	// the state of the request.
 	State string `json:"state"`
+	// whether or not this request was found.
+	NotFound bool `json:"notFound"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/nifi.konpyutaika.com_nifidataflows.yaml
+++ b/config/crd/bases/nifi.konpyutaika.com_nifidataflows.yaml
@@ -151,7 +151,6 @@ spec:
                 - finished
                 - id
                 - lastUpdated
-                - notFound
                 - original
                 - originalCount
                 - originalSize
@@ -185,7 +184,6 @@ spec:
                 - failureReason
                 - id
                 - lastUpdated
-                - notFound
                 - percentCompleted
                 - state
                 - type

--- a/config/crd/bases/nifi.konpyutaika.com_nifidataflows.yaml
+++ b/config/crd/bases/nifi.konpyutaika.com_nifidataflows.yaml
@@ -122,6 +122,8 @@ spec:
                     type: string
                   lastUpdated:
                     type: string
+                  notFound:
+                    type: boolean
                   original:
                     type: string
                   originalCount:
@@ -149,6 +151,7 @@ spec:
                 - finished
                 - id
                 - lastUpdated
+                - notFound
                 - original
                 - originalCount
                 - originalSize
@@ -166,6 +169,8 @@ spec:
                     type: string
                   lastUpdated:
                     type: string
+                  notFound:
+                    type: boolean
                   percentCompleted:
                     format: int32
                     type: integer
@@ -180,6 +185,7 @@ spec:
                 - failureReason
                 - id
                 - lastUpdated
+                - notFound
                 - percentCompleted
                 - state
                 - type

--- a/config/crd/bases/nifi.konpyutaika.com_nifiparametercontexts.yaml
+++ b/config/crd/bases/nifi.konpyutaika.com_nifiparametercontexts.yaml
@@ -94,6 +94,8 @@ spec:
                     type: string
                   lastUpdated:
                     type: string
+                  notFound:
+                    type: boolean
                   percentCompleted:
                     format: int32
                     type: integer
@@ -108,6 +110,7 @@ spec:
                 - failureReason
                 - id
                 - lastUpdated
+                - notFound
                 - percentCompleted
                 - state
                 - submissionTime

--- a/config/crd/bases/nifi.konpyutaika.com_nifiparametercontexts.yaml
+++ b/config/crd/bases/nifi.konpyutaika.com_nifiparametercontexts.yaml
@@ -110,7 +110,6 @@ spec:
                 - failureReason
                 - id
                 - lastUpdated
-                - notFound
                 - percentCompleted
                 - state
                 - submissionTime

--- a/controllers/nifidataflow_controller.go
+++ b/controllers/nifidataflow_controller.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/konpyutaika/nifikop/api/v1"
 	"reflect"
 	"strconv"
+
+	v1 "github.com/konpyutaika/nifikop/api/v1"
 
 	"emperror.dev/errors"
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
@@ -361,6 +362,20 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				errorfactory.NifiFlowDraining,
 				errorfactory.NifiFlowControllerServiceScheduling,
 				errorfactory.NifiFlowScheduling, errorfactory.NifiFlowSyncing:
+				return RequeueAfter(interval)
+			case errorfactory.NifiFlowUpdateRequestNotFound:
+				r.Log.Warn("The update request for dataflow is already gone, there is nothing we can do",
+					zap.String("updateRequest", instance.Status.LatestUpdateRequest.Id),
+					zap.String("clusterName", instance.Spec.ClusterRef.Name),
+					zap.String("flowId", instance.Spec.FlowId),
+					zap.String("dataflow", instance.Name))
+				return RequeueAfter(interval)
+			case errorfactory.NifiConnectionDropRequestNotFound:
+				r.Log.Warn("The drop request for dataflow is already gone, there is nothing we can do",
+					zap.String("updateRequest", instance.Status.LatestDropRequest.Id),
+					zap.String("clusterName", instance.Spec.ClusterRef.Name),
+					zap.String("flowId", instance.Spec.FlowId),
+					zap.String("dataflow", instance.Name))
 				return RequeueAfter(interval)
 			default:
 				r.Recorder.Event(instance, corev1.EventTypeWarning, "SynchronizingFailed",

--- a/controllers/nifiparametercontext_controller.go
+++ b/controllers/nifiparametercontext_controller.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/konpyutaika/nifikop/api/v1"
 	"reflect"
+
+	v1 "github.com/konpyutaika/nifikop/api/v1"
 
 	"emperror.dev/errors"
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
@@ -297,6 +298,11 @@ func (r *NifiParameterContextReconciler) Reconcile(ctx context.Context, req ctrl
 	if err != nil {
 		switch errors.Cause(err).(type) {
 		case errorfactory.NifiParameterContextUpdateRequestRunning:
+			return RequeueAfter(interval)
+		case errorfactory.NifiParameterContextUpdateRequestNotFound:
+			r.Log.Warn("The update request for parameter context is already gone, there is nothing we can do",
+				zap.String("updateRequest", instance.Status.LatestUpdateRequest.Id),
+				zap.String("parameterContext", instance.Name))
 			return RequeueAfter(interval)
 		default:
 			r.Recorder.Event(instance, corev1.EventTypeNormal, "SynchronizingFailed",

--- a/helm/nifikop/crds/nifi.konpyutaika.com_nifidataflows.yaml
+++ b/helm/nifikop/crds/nifi.konpyutaika.com_nifidataflows.yaml
@@ -151,7 +151,6 @@ spec:
                 - finished
                 - id
                 - lastUpdated
-                - notFound
                 - original
                 - originalCount
                 - originalSize
@@ -185,7 +184,6 @@ spec:
                 - failureReason
                 - id
                 - lastUpdated
-                - notFound
                 - percentCompleted
                 - state
                 - type

--- a/helm/nifikop/crds/nifi.konpyutaika.com_nifidataflows.yaml
+++ b/helm/nifikop/crds/nifi.konpyutaika.com_nifidataflows.yaml
@@ -122,6 +122,8 @@ spec:
                     type: string
                   lastUpdated:
                     type: string
+                  notFound:
+                    type: boolean
                   original:
                     type: string
                   originalCount:
@@ -149,6 +151,7 @@ spec:
                 - finished
                 - id
                 - lastUpdated
+                - notFound
                 - original
                 - originalCount
                 - originalSize
@@ -166,6 +169,8 @@ spec:
                     type: string
                   lastUpdated:
                     type: string
+                  notFound:
+                    type: boolean
                   percentCompleted:
                     format: int32
                     type: integer
@@ -180,6 +185,7 @@ spec:
                 - failureReason
                 - id
                 - lastUpdated
+                - notFound
                 - percentCompleted
                 - state
                 - type

--- a/helm/nifikop/crds/nifi.konpyutaika.com_nifiparametercontexts.yaml
+++ b/helm/nifikop/crds/nifi.konpyutaika.com_nifiparametercontexts.yaml
@@ -94,6 +94,8 @@ spec:
                     type: string
                   lastUpdated:
                     type: string
+                  notFound:
+                    type: boolean
                   percentCompleted:
                     format: int32
                     type: integer
@@ -108,6 +110,7 @@ spec:
                 - failureReason
                 - id
                 - lastUpdated
+                - notFound
                 - percentCompleted
                 - state
                 - submissionTime

--- a/helm/nifikop/crds/nifi.konpyutaika.com_nifiparametercontexts.yaml
+++ b/helm/nifikop/crds/nifi.konpyutaika.com_nifiparametercontexts.yaml
@@ -110,7 +110,6 @@ spec:
                 - failureReason
                 - id
                 - lastUpdated
-                - notFound
                 - percentCompleted
                 - state
                 - submissionTime

--- a/pkg/clientwrappers/parametercontext/parametercontext.go
+++ b/pkg/clientwrappers/parametercontext/parametercontext.go
@@ -1,7 +1,7 @@
 package parametercontext
 
 import (
-	"github.com/konpyutaika/nifikop/api/v1"
+	v1 "github.com/konpyutaika/nifikop/api/v1"
 	"github.com/konpyutaika/nifikop/pkg/clientwrappers"
 	"github.com/konpyutaika/nifikop/pkg/common"
 	"github.com/konpyutaika/nifikop/pkg/errorfactory"
@@ -104,7 +104,7 @@ func SyncParameterContext(
 	}
 
 	latestUpdateRequest := parameterContext.Status.LatestUpdateRequest
-	if latestUpdateRequest != nil && !latestUpdateRequest.Complete {
+	if latestUpdateRequest != nil && !latestUpdateRequest.Complete && !latestUpdateRequest.NotFound {
 		updateRequest, err := nClient.GetParameterContextUpdateRequest(parameterContext.Status.Id, latestUpdateRequest.Id)
 		if updateRequest != nil {
 			parameterContext.Status.LatestUpdateRequest = updateRequest2Status(updateRequest)
@@ -115,6 +115,11 @@ func SyncParameterContext(
 				return &parameterContext.Status, err
 			}
 			return &parameterContext.Status, errorfactory.NifiParameterContextUpdateRequestRunning{}
+		}
+
+		if err == nificlient.ErrNifiClusterReturned404 {
+			parameterContext.Status.LatestUpdateRequest.NotFound = true
+			return &parameterContext.Status, errorfactory.NifiParameterContextUpdateRequestNotFound{}
 		}
 	}
 
@@ -134,7 +139,7 @@ func SyncParameterContext(
 
 	var status *v1.NifiParameterContextStatus
 	if parameterContext.Status.Version != *entity.Revision.Version || parameterContext.Status.Id != entity.Id {
-		status := &parameterContext.Status
+		status = &parameterContext.Status
 		status.Version = *entity.Revision.Version
 		status.Id = entity.Id
 	}
@@ -361,5 +366,6 @@ func updateRequest2Status(updateRequest *nigoapi.ParameterContextUpdateRequestEn
 		FailureReason:    ur.FailureReason,
 		PercentCompleted: ur.PercentCompleted,
 		State:            ur.State,
+		NotFound:         false,
 	}
 }

--- a/pkg/errorfactory/errorfactory.go
+++ b/pkg/errorfactory/errorfactory.go
@@ -56,14 +56,23 @@ type NifiClusterTaskFailure struct{ error }
 // NifiConnectionDropping states that flowfile drop is still running
 type NifiConnectionDropping struct{ error }
 
+// NifiConnectionDropRequestNotFound states that flowfile drop request was not found
+type NifiConnectionDropRequestNotFound struct{ error }
+
 // NifiFlowDraining states that flowfile drop is still draining
 type NifiFlowDraining struct{ error }
 
 // NifiParameterContextUpdateRequestRunning states that the parameter context update request is still running
 type NifiParameterContextUpdateRequestRunning struct{ error }
 
+// NifiParameterContextUpdateRequestNotFound states that the parameter context update request was not found
+type NifiParameterContextUpdateRequestNotFound struct{ error }
+
 // NifiFlowUpdateRequestRunning states that the flow update request is still running
 type NifiFlowUpdateRequestRunning struct{ error }
+
+// NifiFlowUpdateRequestNotFound states that the flow update request was not found
+type NifiFlowUpdateRequestNotFound struct{ error }
 
 // NifiFlowControllerServiceScheduling states that the flow's controller service are still scheduling
 type NifiFlowControllerServiceScheduling struct{ error }

--- a/site/docs/5_references/4_nifi_parameter_context.md
+++ b/site/docs/5_references/4_nifi_parameter_context.md
@@ -104,6 +104,7 @@ spec:
 |failureReason|string| an explication of why the request failed, or null if this request has not failed. |Yes| - |
 |percentCompleted|int32| the percentage complete of the request, between 0 and 100. |Yes| - |
 |state|string| the state of the request. |Yes| - |
+|notFoudn|bool| whether or not this request was found. |Yes| false |
 
 ## ParameterContextReference
 

--- a/site/docs/5_references/5_nifi_dataflow.md
+++ b/site/docs/5_references/5_nifi_dataflow.md
@@ -98,6 +98,7 @@ spec:
 |failureReason|string| an explication of why the request failed, or null if this request has not failed. |Yes| - |
 |percentCompleted|int32|  the percentage complete of the request, between 0 and 100. |Yes| 0 |
 |state|string| the state of the request. |Yes| - |
+|notFound|bool| whether or not this request was found. |Yes| - |
 
 ## DropRequest
 
@@ -120,6 +121,7 @@ spec:
 |droppedSize|int64| the size of flow files currently queued in bytes. |Yes| 0 |
 |Dropped|string|the count and size of flow files that have been dropped thus far. |Yes| - |
 |state|string|the state of the request. |Yes| - |
+|notFound|bool|whether or not this request was found. |Yes| false |
 	
 ## DataflowUpdateRequestType
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Change in the management of the UpdateRequest and DropRequest with a new flag to indicate if NiFi can't find the request associated to the ID.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
In some cases, NiFi lost the request (cleaning of the history, etc.) but the operator will be stucked and keep asking NiFi for the request status. So to stop it from spamming NiFi for it, we now say that if NiFi hasn't found the request, we won't ask for it and just move hoping that the request has be done. If not, the operator should find a difference and request the change again.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Spam NiFi for nothing and can cause a latency in the operator reconcile loop.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [ ] Append changelog with changes