### PR TITLE
Make nifikop docker image cross-platform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ orbs:
                 - build/_output
                 - vendor
 
-      # Build job, which build operator docker image (with operator-sdk build)
+      # Build job, which builds the cross-platform operator docker image (with operator-sdk build)
       build-operator:
         <<: *params_operator
         <<: *job_operator
@@ -97,13 +97,13 @@ orbs:
                 - << parameters.operatorDir >>/build/_output
                 - << parameters.operatorDir >>/vendor
           - deploy:
-              name: Push image to Docker Hub
+              name: Build & Push Operator Image to Github Container Registry
               command: |
                 if [[ $(echo "$CIRCLE_BRANCH" | grep -c "pull") -gt 0 ]]; then
-                  echo "This is a PR, we don't push to Hub."
+                  echo "This is a PR, we don't push to GitHub."
                 else
                   docker login ghcr.io -u $GH_NAME --password $GH_TOKEN
-                  make docker-push
+                  make docker-buildx
                 fi
           - save_cache:
               name: Save build artifacts in cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - [PR #220](https://github.com/konpyutaika/nifikop/pull/220) - **[Operator/NifiCluster]** Made `Pod` readiness and liveness checks configurable.
+- [PR #218](https://github.com/konpyutaika/nifikop/pull/218) - **[Operator]** Add cross-platform support to nifikop docker image.
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,12 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 COPY version/ version/
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+# Build the operator
+# TARGETARCH, TARGETOS are automatically set by docker. 
+#   see: https://sdk.operatorframework.io/docs/advanced-topics/multi-arch/#manifest-lists
+#   see: https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
+ARG TARGETOS TARGETARCH
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -137,13 +137,12 @@ docker-build:
 	docker build -t $(REPOSITORY):$(VERSION) .
 
 .PHONY: build
-build: manager manifests docker-build
+build: manager manifests
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
 $(CONTROLLER_GEN): $(LOCALBIN)
 	test -s $(LOCALBIN)/controller-gen || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
-
 
 # Run go fmt against code
 .PHONY: fmt
@@ -256,7 +255,11 @@ docker-buildx: test ## Build and push docker image for the manager for cross-pla
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+ifdef PUSHLATEST
+	- docker buildx build --push --platform=$(PLATFORMS) --tag $(REPOSITORY):$(VERSION) --tag $(REPOSITORY):latest -f Dockerfile.cross .
+else
+	- docker buildx build --push --platform=$(PLATFORMS) --tag $(REPOSITORY):$(VERSION) -f Dockerfile.cross .
+endif
 	- docker buildx rm project-v3-builder
 	rm Dockerfile.cross
 

--- a/docker/build-image/Dockerfile
+++ b/docker/build-image/Dockerfile
@@ -1,5 +1,9 @@
-#https://github.com/CircleCI-Public/circleci-dockerfiles/blob/master/golang/images/1.12.4/Dockerfile
 ARG GOLANG_VERSION
+
+FROM docker as docker-base
+COPY --from=docker/buildx-bin:latest /buildx /usr/libexec/docker/cli-plugins/docker-buildx
+
+#https://github.com/CircleCI-Public/circleci-dockerfiles/blob/master/golang/images/1.12.4/Dockerfile
 FROM golang:${GOLANG_VERSION}
 
 # Make Apt non-interactive
@@ -55,6 +59,9 @@ RUN set -ex \
   && rm -rf /tmp/docker /tmp/docker.tgz \
   && which docker \
   && (docker version || true)
+
+# Install docker-buildx plugin from docker/buildx-bin image
+COPY --from=docker-base /usr/libexec/docker/cli-plugins/docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx
 
 RUN groupadd --gid 3434 circleci \
   && useradd --uid 3434 --gid circleci --shell /bin/bash --create-home circleci \


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #207
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

PR #205 made cross-platform docker image builds possible. This PR makes the nifikop docker image published cross-platform following the below docs:

- https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
- https://sdk.operatorframework.io/docs/advanced-topics/multi-arch/#manifest-lists

**NOTE** This change includes an update to the nifikop build image to install the docker buildx plugin. I've verified locally that the plugin does indeed get installed this way:

```sh
> docker build --build-arg GOLANG_VERSION=1.19 -t nifikop-build:latest .
...
   => => naming to docker.io/library/nifikop-build:latest 
> docker run -it --rm docker.io/library/nifikop-build:latest bash 
...
root@f49830ee84c5:/go/nifikop# docker buildx version
github.com/docker/buildx v0.10.4 c513d34049e499c53468deac6c4267ee72948f02
```

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To enable running nifikop on multiple architectures.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
