### PR TITLE
update golang to 1.20.5 and go mod tidy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ orbs:
     executors:
       operator-build:
         docker:
-          - image: ghcr.io/konpyutaika/docker-images/nifikop-build:1.20
+          - image: ghcr.io/konpyutaika/docker-images/nifikop-build:1.20.5
     # Define jobs list
     jobs:
       # Build job, which build operator docker image (with operator-sdk build)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [PR #257](https://github.com/konpyutaika/nifikop/pull/257) - **[Operator]** Updated the operator-sdk to 1.28.0.
 - [PR #263](https://github.com/konpyutaika/nifikop/pull/263) - **[NiGoApi]** Upgrade nigoapi to v0.0.8.
+- [PR #263](https://github.com/konpyutaika/nifikop/pull/268) - **[Operator]** Upgrade golang to 1.20.5.
 
 ### Fixed Bugs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM golang:1.20.5 as builder
 
 WORKDIR /workspace
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DOCKER_REGISTRY_BASE 	?= ghcr.io/konpyutaika/docker-images
 IMAGE_TAG				?= $(shell git describe --tags --abbrev=0 --match '[0-9].*[0-9].*[0-9]' 2>/dev/null)
 IMAGE_NAME 				?= $(SERVICE_NAME)
 BUILD_IMAGE				?= ghcr.io/konpyutaika/docker-images/nifikop-build
-GOLANG_VERSION          ?= 1.20
+GOLANG_VERSION          ?= 1.20.5
 IMAGE_TAG_BASE ?= <registry>/<operator name>
 OS = $(shell go env GOOS)
 ARCH = $(shell go env GOARCH)

--- a/docker/build-image/Dockerfile
+++ b/docker/build-image/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
   && apt-get install -y \
     git apt \
     locales sudo openssh-client ca-certificates tar gzip \
-    net-tools netcat unzip zip bzip2 gnupg curl wget
+    net-tools netcat-traditional unzip zip bzip2 gnupg curl wget
 
 # Set timezone to UTC by default
 RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,6 @@ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHm
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/konpyutaika/nigoapi v0.0.6 h1:tyzs05rJ1DVbwb3zhdtV/T4k8tfRkAPaydZOGfQFSL0=
-github.com/konpyutaika/nigoapi v0.0.6/go.mod h1:ylinFOIwDzQvM+BbiDFWmr6l2Lexs2pg/jb9znIVAv4=
 github.com/konpyutaika/nigoapi v0.0.8 h1:eOp5Bj7v3PStEqmQrqETncyi5ZRg9k0ooEIZAp71GbU=
 github.com/konpyutaika/nigoapi v0.0.8/go.mod h1:ylinFOIwDzQvM+BbiDFWmr6l2Lexs2pg/jb9znIVAv4=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Updates golang to latest version: 1.20.5

This change updates the build image, so it will need to be pushed.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Unit tests are failing due to a vulnerability in golang 1.20.3: https://app.circleci.com/pipelines/github/konpyutaika/nifikop/837/workflows/3c2a54ac-8f1e-4088-aa6c-8f23f1d73fbc/jobs/2172

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
