### PR TITLE
Update resource's status only on change

### DIFF
--- a/controllers/nifiparametercontext_controller.go
+++ b/controllers/nifiparametercontext_controller.go
@@ -277,7 +277,7 @@ func (r *NifiParameterContextReconciler) Reconcile(ctx context.Context, req ctrl
 		}
 
 		instance.Status = *status
-		if err := r.Client.Status().Update(ctx, instance); err != nil {
+		if err := r.updateStatus(ctx, instance, current.Status); err != nil {
 			return RequeueWithError(r.Log, "failed to update status for NifiParameterContext "+instance.Name, err)
 		}
 
@@ -291,7 +291,7 @@ func (r *NifiParameterContextReconciler) Reconcile(ctx context.Context, req ctrl
 	status, err := parametercontext.SyncParameterContext(instance, parameterSecrets, parameterContextRefs, clientConfig)
 	if status != nil {
 		instance.Status = *status
-		if err := r.Client.Status().Update(ctx, instance); err != nil {
+		if err := r.updateStatus(ctx, instance, current.Status); err != nil {
 			return RequeueWithError(r.Log, "failed to update status for NifiParameterContext "+instance.Name, err)
 		}
 	}
@@ -415,5 +415,12 @@ func (r *NifiParameterContextReconciler) finalizeNifiParameterContext(
 	r.Log.Info("Deleted NifiParameter Context",
 		zap.String("parameterContext", parameterContext.Name))
 
+	return nil
+}
+
+func (r *NifiParameterContextReconciler) updateStatus(ctx context.Context, parameterContext *v1.NifiParameterContext, currentStatus v1.NifiParameterContextStatus) error {
+	if !reflect.DeepEqual(parameterContext.Status, currentStatus) {
+		return r.Client.Status().Update(ctx, parameterContext)
+	}
 	return nil
 }

--- a/controllers/nifiregistryclient_controller.go
+++ b/controllers/nifiregistryclient_controller.go
@@ -212,7 +212,7 @@ func (r *NifiRegistryClientReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 
 		instance.Status = *status
-		if err := r.Client.Status().Update(ctx, instance); err != nil {
+		if err := r.updateStatus(ctx, instance, current.Status); err != nil {
 			return RequeueWithError(r.Log, "failed to update status for NifiRegistryClient "+instance.Name, err)
 		}
 
@@ -240,7 +240,7 @@ func (r *NifiRegistryClientReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	instance.Status = *status
-	if err := r.Client.Status().Update(ctx, instance); err != nil {
+	if err := r.updateStatus(ctx, instance, current.Status); err != nil {
 		return RequeueWithError(r.Log, "failed to update status for NifiRegistryClient "+instance.Name, err)
 	}
 
@@ -340,5 +340,12 @@ func (r *NifiRegistryClientReconciler) finalizeNifiRegistryClient(registryClient
 	r.Log.Info("Deleted Registry client",
 		zap.String("registryClient", registryClient.Name))
 
+	return nil
+}
+
+func (r *NifiRegistryClientReconciler) updateStatus(ctx context.Context, registryClient *v1.NifiRegistryClient, currentStatus v1.NifiRegistryClientStatus) error {
+	if !reflect.DeepEqual(registryClient.Status, currentStatus) {
+		return r.Client.Status().Update(ctx, registryClient)
+	}
 	return nil
 }

--- a/controllers/nifiuser_controller.go
+++ b/controllers/nifiuser_controller.go
@@ -312,7 +312,7 @@ func (r *NifiUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 
 		instance.Status = *status
-		if err := r.Client.Status().Update(ctx, instance); err != nil {
+		if err := r.updateStatus(ctx, instance, current.Status); err != nil {
 			return RequeueWithError(r.Log, "failed to update status for NifiUser "+instance.Name, err)
 		}
 		r.Recorder.Event(instance, corev1.EventTypeNormal, "Created",
@@ -328,7 +328,7 @@ func (r *NifiUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	instance.Status = *status
-	if err := r.Client.Status().Update(ctx, instance); err != nil {
+	if err := r.updateStatus(ctx, instance, current.Status); err != nil {
 		return RequeueWithError(r.Log, "failed to update status for NifiUser "+instance.Name, err)
 	}
 
@@ -436,4 +436,11 @@ func (r *NifiUserReconciler) addFinalizer(user *v1.NifiUser) {
 	r.Log.Debug("Adding Finalizer for the NifiUser",
 		zap.String("user", user.Name))
 	user.SetFinalizers(append(user.GetFinalizers(), userFinalizer))
+}
+
+func (r *NifiUserReconciler) updateStatus(ctx context.Context, user *v1.NifiUser, currentStatus v1.NifiUserStatus) error {
+	if !reflect.DeepEqual(user.Status, currentStatus) {
+		return r.Client.Status().Update(ctx, user)
+	}
+	return nil
 }

--- a/controllers/nifiusergroup_controller.go
+++ b/controllers/nifiusergroup_controller.go
@@ -254,7 +254,7 @@ func (r *NifiUserGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 
 		instance.Status = *status
-		if err := r.Client.Status().Update(ctx, instance); err != nil {
+		if err := r.updateStatus(ctx, instance, current.Status); err != nil {
 			return RequeueWithError(r.Log, "failed to update status for NifiUserGroup "+instance.Name, err)
 		}
 
@@ -273,7 +273,7 @@ func (r *NifiUserGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	instance.Status = *status
-	if err := r.Client.Status().Update(ctx, instance); err != nil {
+	if err := r.updateStatus(ctx, instance, current.Status); err != nil {
 		return RequeueWithError(r.Log, "failed to update status for NifiUserGroup "+instance.Name, err)
 	}
 
@@ -377,5 +377,12 @@ func (r *NifiUserGroupReconciler) finalizeNifiNifiUserGroup(
 	r.Log.Info("Deleted NifiUserGroup",
 		zap.String("userGroup", userGroup.Name))
 
+	return nil
+}
+
+func (r *NifiUserGroupReconciler) updateStatus(ctx context.Context, userGroup *v1.NifiUserGroup, currentStatus v1.NifiUserGroupStatus) error {
+	if !reflect.DeepEqual(userGroup.Status, currentStatus) {
+		return r.Client.Status().Update(ctx, userGroup)
+	}
 	return nil
 }

--- a/pkg/k8sutil/resource.go
+++ b/pkg/k8sutil/resource.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Reconcile reconciles K8S resources
-func Reconcile(log zap.Logger, client runtimeClient.Client, desired runtimeClient.Object, cr *nifikopv1.NifiCluster) error {
+func Reconcile(log zap.Logger, client runtimeClient.Client, desired runtimeClient.Object, cr *nifikopv1.NifiCluster, currentStatus *nifikopv1.NifiClusterStatus) error {
 	desiredType := reflect.TypeOf(desired)
 	current := desired.DeepCopyObject().(runtimeClient.Object)
 
@@ -92,7 +92,7 @@ func Reconcile(log zap.Logger, client runtimeClient.Client, desired runtimeClien
 				case *corev1.ConfigMap:
 					// Only update status when configmap belongs to node
 					if id, ok := desired.Labels["nodeId"]; ok {
-						statusErr := UpdateNodeStatus(client, []string{id}, cr, nifikopv1.ConfigOutOfSync, log)
+						statusErr := UpdateNodeStatus(client, []string{id}, cr, *currentStatus, nifikopv1.ConfigOutOfSync, log)
 						if statusErr != nil {
 							return errors.WrapIfWithDetails(err, "updating status for resource failed", "kind", desiredType)
 						}
@@ -100,7 +100,7 @@ func Reconcile(log zap.Logger, client runtimeClient.Client, desired runtimeClien
 				case *corev1.Secret:
 					// Only update status when secret belongs to node
 					if id, ok := desired.Labels["nodeId"]; ok {
-						statusErr := UpdateNodeStatus(client, []string{id}, cr, nifikopv1.ConfigOutOfSync, log)
+						statusErr := UpdateNodeStatus(client, []string{id}, cr, *currentStatus, nifikopv1.ConfigOutOfSync, log)
 						if statusErr != nil {
 							return errors.WrapIfWithDetails(err, "updating status for resource failed", "kind", desiredType)
 						}

--- a/pkg/k8sutil/status.go
+++ b/pkg/k8sutil/status.go
@@ -3,9 +3,11 @@ package k8sutil
 import (
 	"context"
 	"fmt"
-	"github.com/konpyutaika/nifikop/api/v1"
+	"reflect"
 	"strings"
 	"time"
+
+	v1 "github.com/konpyutaika/nifikop/api/v1"
 
 	"go.uber.org/zap"
 
@@ -28,7 +30,7 @@ func IsMarkedForDeletion(m metav1.ObjectMeta) bool {
 }
 
 // UpdateNodeStatus updates the node status with rack and configuration infos
-func UpdateNodeStatus(c client.Client, nodeIds []string, cluster *v1.NifiCluster, state interface{}, logger zap.Logger) error {
+func UpdateNodeStatus(c client.Client, nodeIds []string, cluster *v1.NifiCluster, currentStatus v1.NifiClusterStatus, state interface{}, logger zap.Logger) error {
 	typeMeta := cluster.TypeMeta
 
 	for _, nodeId := range nodeIds {
@@ -88,82 +90,84 @@ func UpdateNodeStatus(c client.Client, nodeIds []string, cluster *v1.NifiCluster
 		}
 	}
 
-	err := c.Status().Update(context.Background(), cluster)
-	if apierrors.IsNotFound(err) {
-		err = c.Update(context.Background(), cluster)
-	}
-	if err != nil {
-		if !apierrors.IsConflict(err) {
-			return errors.WrapIff(err, "could not update Nifi node(s) %s state", strings.Join(nodeIds, ","))
+	if !reflect.DeepEqual(cluster.Status, currentStatus) {
+		err := c.Status().Update(context.Background(), cluster)
+		if apierrors.IsNotFound(err) {
+			err = c.Update(context.Background(), cluster)
 		}
-		err := c.Get(context.TODO(), types.NamespacedName{
-			Namespace: cluster.Namespace,
-			Name:      cluster.Name,
-		}, cluster)
 		if err != nil {
-			return errors.WrapIf(err, "could not get config for updating status")
-		}
+			if !apierrors.IsConflict(err) {
+				return errors.WrapIff(err, "could not update Nifi node(s) %s state", strings.Join(nodeIds, ","))
+			}
+			err := c.Get(context.TODO(), types.NamespacedName{
+				Namespace: cluster.Namespace,
+				Name:      cluster.Name,
+			}, cluster)
+			if err != nil {
+				return errors.WrapIf(err, "could not get config for updating status")
+			}
 
-		for _, nodeId := range nodeIds {
+			for _, nodeId := range nodeIds {
 
-			if cluster.Status.NodesState == nil {
-				switch s := state.(type) {
-				case v1.GracefulActionState:
-					cluster.Status.NodesState = map[string]v1.NodeState{nodeId: {GracefulActionState: s}}
-				case v1.ConfigurationState:
-					cluster.Status.NodesState = map[string]v1.NodeState{nodeId: {ConfigurationState: s}}
-				case v1.InitClusterNode:
-					cluster.Status.NodesState = map[string]v1.NodeState{nodeId: {InitClusterNode: s}}
-				case bool:
-					cluster.Status.NodesState = map[string]v1.NodeState{nodeId: {PodIsReady: s}}
-				case metav1.Time:
-					if cluster.Status.NodesState[nodeId].CreationTime == nil {
-						cluster.Status.NodesState = map[string]v1.NodeState{nodeId: {CreationTime: &s}}
-					} else {
-						cluster.Status.NodesState = map[string]v1.NodeState{nodeId: {LastUpdatedTime: s}}
+				if cluster.Status.NodesState == nil {
+					switch s := state.(type) {
+					case v1.GracefulActionState:
+						cluster.Status.NodesState = map[string]v1.NodeState{nodeId: {GracefulActionState: s}}
+					case v1.ConfigurationState:
+						cluster.Status.NodesState = map[string]v1.NodeState{nodeId: {ConfigurationState: s}}
+					case v1.InitClusterNode:
+						cluster.Status.NodesState = map[string]v1.NodeState{nodeId: {InitClusterNode: s}}
+					case bool:
+						cluster.Status.NodesState = map[string]v1.NodeState{nodeId: {PodIsReady: s}}
+					case metav1.Time:
+						if cluster.Status.NodesState[nodeId].CreationTime == nil {
+							cluster.Status.NodesState = map[string]v1.NodeState{nodeId: {CreationTime: &s}}
+						} else {
+							cluster.Status.NodesState = map[string]v1.NodeState{nodeId: {LastUpdatedTime: s}}
+						}
 					}
-				}
-			} else if val, ok := cluster.Status.NodesState[nodeId]; ok {
-				switch s := state.(type) {
-				case v1.GracefulActionState:
-					val.GracefulActionState = s
-				case v1.ConfigurationState:
-					val.ConfigurationState = s
-				case v1.InitClusterNode:
-					val.InitClusterNode = s
-				case bool:
-					val.PodIsReady = s
-				case metav1.Time:
-					if cluster.Status.NodesState[nodeId].CreationTime == nil {
-						val.CreationTime = &s
-					} else {
-						val.LastUpdatedTime = s
+				} else if val, ok := cluster.Status.NodesState[nodeId]; ok {
+					switch s := state.(type) {
+					case v1.GracefulActionState:
+						val.GracefulActionState = s
+					case v1.ConfigurationState:
+						val.ConfigurationState = s
+					case v1.InitClusterNode:
+						val.InitClusterNode = s
+					case bool:
+						val.PodIsReady = s
+					case metav1.Time:
+						if cluster.Status.NodesState[nodeId].CreationTime == nil {
+							val.CreationTime = &s
+						} else {
+							val.LastUpdatedTime = s
+						}
 					}
-				}
-				cluster.Status.NodesState[nodeId] = val
-			} else {
-				switch s := state.(type) {
-				case v1.GracefulActionState:
-					cluster.Status.NodesState[nodeId] = v1.NodeState{GracefulActionState: s}
-				case v1.ConfigurationState:
-					cluster.Status.NodesState[nodeId] = v1.NodeState{ConfigurationState: s}
-				case v1.InitClusterNode:
-					cluster.Status.NodesState[nodeId] = v1.NodeState{InitClusterNode: s}
-				case bool:
-					cluster.Status.NodesState[nodeId] = v1.NodeState{PodIsReady: s}
-				case metav1.Time:
-					if cluster.Status.NodesState[nodeId].CreationTime == nil {
-						cluster.Status.NodesState = map[string]v1.NodeState{nodeId: {CreationTime: &s}}
-					} else {
-						cluster.Status.NodesState = map[string]v1.NodeState{nodeId: {LastUpdatedTime: s}}
+					cluster.Status.NodesState[nodeId] = val
+				} else {
+					switch s := state.(type) {
+					case v1.GracefulActionState:
+						cluster.Status.NodesState[nodeId] = v1.NodeState{GracefulActionState: s}
+					case v1.ConfigurationState:
+						cluster.Status.NodesState[nodeId] = v1.NodeState{ConfigurationState: s}
+					case v1.InitClusterNode:
+						cluster.Status.NodesState[nodeId] = v1.NodeState{InitClusterNode: s}
+					case bool:
+						cluster.Status.NodesState[nodeId] = v1.NodeState{PodIsReady: s}
+					case metav1.Time:
+						if cluster.Status.NodesState[nodeId].CreationTime == nil {
+							cluster.Status.NodesState = map[string]v1.NodeState{nodeId: {CreationTime: &s}}
+						} else {
+							cluster.Status.NodesState = map[string]v1.NodeState{nodeId: {LastUpdatedTime: s}}
+						}
 					}
 				}
 			}
-		}
 
-		err = updateClusterStatus(c, cluster)
-		if err != nil {
-			return errors.WrapIff(err, "could not update Nifi clusters node(s) %s state", strings.Join(nodeIds, ","))
+			err = updateClusterStatus(c, cluster, currentStatus)
+			if err != nil {
+				return errors.WrapIff(err, "could not update Nifi clusters node(s) %s state", strings.Join(nodeIds, ","))
+			}
 		}
 	}
 	// update loses the typeMeta of the config that's used later when setting ownerrefs
@@ -175,7 +179,7 @@ func UpdateNodeStatus(c client.Client, nodeIds []string, cluster *v1.NifiCluster
 }
 
 // DeleteStatus deletes the given node state from the CR
-func DeleteStatus(c client.Client, nodeId string, cluster *v1.NifiCluster, logger zap.Logger) error {
+func DeleteStatus(c client.Client, nodeId string, cluster *v1.NifiCluster, currentStatus v1.NifiClusterStatus, logger zap.Logger) error {
 	typeMeta := cluster.TypeMeta
 
 	nodeStatus := cluster.Status.NodesState
@@ -184,29 +188,31 @@ func DeleteStatus(c client.Client, nodeId string, cluster *v1.NifiCluster, logge
 
 	cluster.Status.NodesState = nodeStatus
 
-	err := c.Status().Update(context.Background(), cluster)
-	if apierrors.IsNotFound(err) {
-		err = c.Update(context.Background(), cluster)
-	}
-	if err != nil {
-		if !apierrors.IsConflict(err) {
-			return errors.WrapIff(err, "could not delete Nifi cluster node %s state ", nodeId)
+	if !reflect.DeepEqual(cluster.Status, currentStatus) {
+		err := c.Status().Update(context.Background(), cluster)
+		if apierrors.IsNotFound(err) {
+			err = c.Update(context.Background(), cluster)
 		}
-		err := c.Get(context.TODO(), types.NamespacedName{
-			Namespace: cluster.Namespace,
-			Name:      cluster.Name,
-		}, cluster)
 		if err != nil {
-			return errors.WrapIf(err, "could not get config for updating status")
-		}
-		nodeStatus = cluster.Status.NodesState
+			if !apierrors.IsConflict(err) {
+				return errors.WrapIff(err, "could not delete Nifi cluster node %s state ", nodeId)
+			}
+			err := c.Get(context.TODO(), types.NamespacedName{
+				Namespace: cluster.Namespace,
+				Name:      cluster.Name,
+			}, cluster)
+			if err != nil {
+				return errors.WrapIf(err, "could not get config for updating status")
+			}
+			nodeStatus = cluster.Status.NodesState
 
-		delete(nodeStatus, nodeId)
+			delete(nodeStatus, nodeId)
 
-		cluster.Status.NodesState = nodeStatus
-		err = updateClusterStatus(c, cluster)
-		if err != nil {
-			return errors.WrapIff(err, "could not delete Nifi clusters node %s state ", nodeId)
+			cluster.Status.NodesState = nodeStatus
+			err = updateClusterStatus(c, cluster, currentStatus)
+			if err != nil {
+				return errors.WrapIff(err, "could not delete Nifi clusters node %s state ", nodeId)
+			}
 		}
 	}
 
@@ -217,7 +223,7 @@ func DeleteStatus(c client.Client, nodeId string, cluster *v1.NifiCluster, logge
 }
 
 // UpdateCRStatus updates the cluster state
-func UpdateCRStatus(c client.Client, cluster *v1.NifiCluster, state interface{}, logger zap.Logger) error {
+func UpdateCRStatus(c client.Client, cluster *v1.NifiCluster, currentStatus v1.NifiClusterStatus, state interface{}, logger zap.Logger) error {
 	typeMeta := cluster.TypeMeta
 
 	switch s := state.(type) {
@@ -225,29 +231,31 @@ func UpdateCRStatus(c client.Client, cluster *v1.NifiCluster, state interface{},
 		cluster.Status.State = s
 	}
 
-	err := c.Status().Update(context.Background(), cluster)
-	if apierrors.IsNotFound(err) {
-		err = c.Update(context.Background(), cluster)
-	}
-	if err != nil {
-		if !apierrors.IsConflict(err) {
-			return errors.WrapIf(err, "could not update CR state")
+	if !reflect.DeepEqual(cluster.Status, currentStatus) {
+		err := c.Status().Update(context.Background(), cluster)
+		if apierrors.IsNotFound(err) {
+			err = c.Update(context.Background(), cluster)
 		}
-		err := c.Get(context.TODO(), types.NamespacedName{
-			Namespace: cluster.Namespace,
-			Name:      cluster.Name,
-		}, cluster)
 		if err != nil {
-			return errors.WrapIf(err, "could not get config for updating status")
-		}
-		switch s := state.(type) {
-		case v1.ClusterState:
-			cluster.Status.State = s
-		}
+			if !apierrors.IsConflict(err) {
+				return errors.WrapIf(err, "could not update CR state")
+			}
+			err := c.Get(context.TODO(), types.NamespacedName{
+				Namespace: cluster.Namespace,
+				Name:      cluster.Name,
+			}, cluster)
+			if err != nil {
+				return errors.WrapIf(err, "could not get config for updating status")
+			}
+			switch s := state.(type) {
+			case v1.ClusterState:
+				cluster.Status.State = s
+			}
 
-		err = updateClusterStatus(c, cluster)
-		if err != nil {
-			return errors.WrapIf(err, "could not update CR state")
+			err = updateClusterStatus(c, cluster, currentStatus)
+			if err != nil {
+				return errors.WrapIf(err, "could not update CR state")
+			}
 		}
 	}
 	// update loses the typeMeta of the config that's used later when setting ownerrefs
@@ -256,31 +264,33 @@ func UpdateCRStatus(c client.Client, cluster *v1.NifiCluster, state interface{},
 }
 
 // UpdateRootProcessGroupIdStatus updates the cluster root process group id
-func UpdateRootProcessGroupIdStatus(c client.Client, cluster *v1.NifiCluster, id string, logger zap.Logger) error {
+func UpdateRootProcessGroupIdStatus(c client.Client, cluster *v1.NifiCluster, currentStatus v1.NifiClusterStatus, id string, logger zap.Logger) error {
 	typeMeta := cluster.TypeMeta
 
 	cluster.Status.RootProcessGroupId = id
 
-	err := c.Status().Update(context.Background(), cluster)
-	if apierrors.IsNotFound(err) {
-		err = c.Update(context.Background(), cluster)
-	}
-	if err != nil {
-		if !apierrors.IsConflict(err) {
-			return errors.WrapIf(err, "could not update CR state")
+	if !reflect.DeepEqual(cluster.Status, currentStatus) {
+		err := c.Status().Update(context.Background(), cluster)
+		if apierrors.IsNotFound(err) {
+			err = c.Update(context.Background(), cluster)
 		}
-		err := c.Get(context.TODO(), types.NamespacedName{
-			Namespace: cluster.Namespace,
-			Name:      cluster.Name,
-		}, cluster)
 		if err != nil {
-			return errors.WrapIf(err, "could not get config for updating status")
-		}
-		cluster.Status.RootProcessGroupId = id
+			if !apierrors.IsConflict(err) {
+				return errors.WrapIf(err, "could not update CR state")
+			}
+			err := c.Get(context.TODO(), types.NamespacedName{
+				Namespace: cluster.Namespace,
+				Name:      cluster.Name,
+			}, cluster)
+			if err != nil {
+				return errors.WrapIf(err, "could not get config for updating status")
+			}
+			cluster.Status.RootProcessGroupId = id
 
-		err = updateClusterStatus(c, cluster)
-		if err != nil {
-			return errors.WrapIf(err, "could not update CR state")
+			err = updateClusterStatus(c, cluster, currentStatus)
+			if err != nil {
+				return errors.WrapIf(err, "could not update CR state")
+			}
 		}
 	}
 	// update loses the typeMeta of the config that's used later when setting ownerrefs
@@ -292,36 +302,40 @@ func UpdateRootProcessGroupIdStatus(c client.Client, cluster *v1.NifiCluster, id
 }
 
 // UpdateRollingUpgradeState updates the state of the cluster with rolling upgrade info
-func UpdateRollingUpgradeState(c client.Client, cluster *v1.NifiCluster, time time.Time, logger zap.Logger) error {
+func UpdateRollingUpgradeState(c client.Client, cluster *v1.NifiCluster, currentStatus v1.NifiClusterStatus, time time.Time, logger zap.Logger) error {
 	typeMeta := cluster.TypeMeta
 
 	timeStamp := time.Format("Mon, 2 Jan 2006 15:04:05 GMT")
 	cluster.Status.RollingUpgrade.LastSuccess = timeStamp
 
-	err := c.Status().Update(context.Background(), cluster)
-	if apierrors.IsNotFound(err) {
-		err = c.Update(context.Background(), cluster)
-	}
-	if err != nil {
-		if !apierrors.IsConflict(err) {
-			return errors.WrapIf(err, "could not update rolling upgrade state")
-		}
-		err := c.Get(context.TODO(), types.NamespacedName{
-			Namespace: cluster.Namespace,
-			Name:      cluster.Name,
-		}, cluster)
-		if err != nil {
-			return errors.WrapIf(err, "could not get config for updating status")
-		}
-
-		cluster.Status.RollingUpgrade.LastSuccess = timeStamp
-
-		err = c.Status().Update(context.Background(), cluster)
+	if !reflect.DeepEqual(cluster.Status, currentStatus) {
+		err := c.Status().Update(context.Background(), cluster)
 		if apierrors.IsNotFound(err) {
 			err = c.Update(context.Background(), cluster)
 		}
 		if err != nil {
-			return errors.WrapIf(err, "could not update rolling upgrade state")
+			if !apierrors.IsConflict(err) {
+				return errors.WrapIf(err, "could not update rolling upgrade state")
+			}
+			err := c.Get(context.TODO(), types.NamespacedName{
+				Namespace: cluster.Namespace,
+				Name:      cluster.Name,
+			}, cluster)
+			if err != nil {
+				return errors.WrapIf(err, "could not get config for updating status")
+			}
+
+			cluster.Status.RollingUpgrade.LastSuccess = timeStamp
+
+			if !reflect.DeepEqual(cluster.Status, currentStatus) {
+				err = c.Status().Update(context.Background(), cluster)
+				if apierrors.IsNotFound(err) {
+					err = c.Update(context.Background(), cluster)
+				}
+				if err != nil {
+					return errors.WrapIf(err, "could not update rolling upgrade state")
+				}
+			}
 		}
 	}
 	// update loses the typeMeta of the config that's used later when setting ownerrefs
@@ -330,10 +344,12 @@ func UpdateRollingUpgradeState(c client.Client, cluster *v1.NifiCluster, time ti
 	return nil
 }
 
-func updateClusterStatus(c client.Client, cluster *v1.NifiCluster) error {
-	err := c.Status().Update(context.Background(), cluster)
-	if apierrors.IsNotFound(err) {
-		return c.Update(context.Background(), cluster)
+func updateClusterStatus(c client.Client, cluster *v1.NifiCluster, currentStatus v1.NifiClusterStatus) error {
+	if !reflect.DeepEqual(cluster.Status, currentStatus) {
+		err := c.Status().Update(context.Background(), cluster)
+		if apierrors.IsNotFound(err) {
+			return c.Update(context.Background(), cluster)
+		}
 	}
 	return nil
 }

--- a/pkg/nificlient/config/basic/basic_config.go
+++ b/pkg/nificlient/config/basic/basic_config.go
@@ -5,10 +5,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"github.com/konpyutaika/nifikop/api/v1"
 	"strconv"
 	"strings"
 	"time"
+
+	v1 "github.com/konpyutaika/nifikop/api/v1"
 
 	"emperror.dev/errors"
 	"github.com/golang-jwt/jwt/v4"
@@ -190,7 +191,7 @@ func clusterConfig(client client.Client, cluster *v1.NifiCluster) (*clientconfig
 		),
 		Data: data,
 	}
-	err = k8sutil.Reconcile(*log, client, secret, nil)
+	err = k8sutil.Reconcile(*log, client, secret, nil, nil)
 	if err != nil {
 		return nil, errors.WrapIfWithDetails(err, "failed to reconcile resource", "resource", secret.GetObjectKind().GroupVersionKind())
 	}

--- a/pkg/resources/reconciler.go
+++ b/pkg/resources/reconciler.go
@@ -1,7 +1,7 @@
 package resources
 
 import (
-	"github.com/konpyutaika/nifikop/api/v1"
+	v1 "github.com/konpyutaika/nifikop/api/v1"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -11,8 +11,9 @@ import (
 // Reconciler holds CR for Nifi
 type Reconciler struct {
 	client.Client
-	DirectClient client.Reader
-	NifiCluster  *v1.NifiCluster
+	DirectClient             client.Reader
+	NifiCluster              *v1.NifiCluster
+	NifiClusterCurrentStatus v1.NifiClusterStatus
 }
 
 // ComponentReconciler describes the Reconcile method


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Update controllers to update resource status only if a modification has been made.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
In GKE, even if no changes have been made to the state, the update call always generates logs. So the more resources you have, the more logs you have, and since in GCP these logs are invoiced, the bill becomes high. And also to reduce the load on K8S.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [ ] Append changelog with changes