### PR TITLE
Change default sensitive algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- [PR #290](https://github.com/konpyutaika/nifikop/pull/290) - **[Operator/NifiCluster]** Change default sensitive algorithm
+
 ### Fixed Bugs
 
 ### Deprecated

--- a/pkg/resources/templates/config/nifi_properties.go
+++ b/pkg/resources/templates/config/nifi_properties.go
@@ -147,7 +147,7 @@ nifi.web.jetty.threads=200
 # security properties #
 nifi.sensitive.props.key=
 nifi.sensitive.props.key.protected=
-nifi.sensitive.props.algorithm=PBEWITHMD5AND256BITAES-CBC-OPENSSL
+nifi.sensitive.props.algorithm=NIFI_PBKDF2_AES_GCM_256
 nifi.sensitive.props.provider=BC
 nifi.sensitive.props.additional.keys=
 

--- a/site/docs/7_upgrade_guides/4_v1.3.1_to_v1.4.0.md
+++ b/site/docs/7_upgrade_guides/4_v1.3.1_to_v1.4.0.md
@@ -1,0 +1,39 @@
+---
+id: 4_v1.3.1_to_v1.4.0
+title: v1.3.1 to v1.4.0
+sidebar_label: v1.3.1 to v1.4.0
+---
+
+[PR #290](https://github.com/konpyutaika/nifikop/pull/290) changed the default NiFi senstive algorithm from `PBEWITHMD5AND256BITAES-CBC-OPENSSL` to `NIFI_PBKDF2_AES_GCM_256`. If you have overridden the property `nifi.sensitive.props.algorithm` in the `nifi.properties` then you can ignored this guide.
+
+
+# Getting started
+
+If you have overridden the default `nifi.sensitive.props.algorithm`, then there are no special upgrade instructions. If you have, you need to upadate the flow configuration to recalculate the sensitive value beforehand. To do so, you need to use the [NiFi Encrypt-Config Tool](https://nifi.apache.org/docs/nifi-docs/html/toolkit-guide.html#encrypt_config_tool) to change the algorithm.
+
+```sh
+encrypt-config.sh -n nifi.properties -f flow.xml.gz -x -s PROPERTIES_KEY -A NIFI_PBKDF2_AES_GCM_256
+encrypt-config.sh -n nifi.properties -f flow.json.gz -x -s PROPERTIES_KEY -A NIFI_PBKDF2_AES_GCM_256
+```
+
+> Source: https://exceptionfactory.com/posts/2021/07/29/deciphering-apache-nifi-component-property-encryption/
+
+You can do this automatically using an `initContainer`. To do this, you stop the operator, update the `NifiCluster` with this new `initContainer` and then upgrade and restart the operator.
+
+```yaml
+initContainers:
+  - image: "apache/nifi-toolkit:latest"
+    name: nifi-toolkit
+    imagePullPolicy: Always
+    command:
+      - "sh"
+      - "-c"
+      - "NIFI_SENSITIVE_PROPS_KEY=$(grep 'nifi.sensitive.props.key' /opt/nifi/nifi-current/conf/nifi.properties | cut -d'=' -f2) && bin/encrypt-config.sh -n /opt/nifi/nifi-current/conf/nifi.properties -f /opt/nifi/data/flow.json.gz -x -A NIFI_PBKDF2_AES_GCM_256 -s $NIFI_SENSITIVE_PROPS_KEY; bin/encrypt-config.sh -n /opt/nifi/nifi-current/conf/nifi.properties -f /opt/nifi/data/flow.xml.gz -x -A NIFI_PBKDF2_AES_GCM_256 -s $NIFI_SENSITIVE_PROPS_KEY"
+    volumeMounts:
+      - name: data
+        mountPath: /opt/nifi/data
+      - name: conf
+        mountPath: /opt/nifi/nifi-current/conf
+```
+
+> Adapt the `volumeMounts` and `mountPath` to your needs.

--- a/site/docs/7_upgrade_guides/4_v1.3.1_to_v1.4.0.md
+++ b/site/docs/7_upgrade_guides/4_v1.3.1_to_v1.4.0.md
@@ -4,7 +4,7 @@ title: v1.3.1 to v1.4.0
 sidebar_label: v1.3.1 to v1.4.0
 ---
 
-[PR #290](https://github.com/konpyutaika/nifikop/pull/290) changed the default NiFi senstive algorithm from `PBEWITHMD5AND256BITAES-CBC-OPENSSL` to `NIFI_PBKDF2_AES_GCM_256`. If you have overridden the property `nifi.sensitive.props.algorithm` in the `nifi.properties` then you can ignored this guide.
+[PR #290](https://github.com/konpyutaika/nifikop/pull/290) changed the default NiFi senstive algorithm from `PBEWITHMD5AND256BITAES-CBC-OPENSSL` to `NIFI_PBKDF2_AES_GCM_256`. If you have overridden the property `nifi.sensitive.props.algorithm` in the `nifi.properties` then you can ignore this guide.
 
 # Getting started
 

--- a/site/docs/7_upgrade_guides/4_v1.3.1_to_v1.4.0.md
+++ b/site/docs/7_upgrade_guides/4_v1.3.1_to_v1.4.0.md
@@ -17,7 +17,7 @@ encrypt-config.sh -n nifi.properties -f flow.json.gz -x -s PROPERTIES_KEY -A NIF
 
 > Source: https://exceptionfactory.com/posts/2021/07/29/deciphering-apache-nifi-component-property-encryption/
 
-You can do this automatically using an `initContainer`. To do this, you stop the operator, update the `NifiCluster` with this new `initContainer` and then upgrade and restart the operator.
+You can do this automatically using an `initContainer`. To do this, you stop the operator, update the `NifiCluster` with this new `initContainer` and then upgrade and restart the operator. Finally, you can remove the `initContainer`.
 
 ```yaml
 initContainers:

--- a/site/docs/7_upgrade_guides/4_v1.3.1_to_v1.4.0.md
+++ b/site/docs/7_upgrade_guides/4_v1.3.1_to_v1.4.0.md
@@ -6,7 +6,6 @@ sidebar_label: v1.3.1 to v1.4.0
 
 [PR #290](https://github.com/konpyutaika/nifikop/pull/290) changed the default NiFi senstive algorithm from `PBEWITHMD5AND256BITAES-CBC-OPENSSL` to `NIFI_PBKDF2_AES_GCM_256`. If you have overridden the property `nifi.sensitive.props.algorithm` in the `nifi.properties` then you can ignored this guide.
 
-
 # Getting started
 
 If you have overridden the default `nifi.sensitive.props.algorithm`, then there are no special upgrade instructions. If you have, you need to upadate the flow configuration to recalculate the sensitive value beforehand. To do so, you need to use the [NiFi Encrypt-Config Tool](https://nifi.apache.org/docs/nifi-docs/html/toolkit-guide.html#encrypt_config_tool) to change the algorithm.

--- a/site/website/sidebars.json
+++ b/site/website/sidebars.json
@@ -137,7 +137,8 @@
       "items": [
         "7_upgrade_guides/1_v0.7.x_to_v0.8.0",
         "7_upgrade_guides/2_v0.14.1_to_v0.15.0",
-        "7_upgrade_guides/3_v0.16.0_to_v1.0.0"
+        "7_upgrade_guides/3_v0.16.0_to_v1.0.0",
+        "7_upgrade_guides/4_v1.3.1_to_v1.4.0"
       ]
     }
   ]


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Change of the default sensitive algorithm in the `nifi.properties` file.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The old one is deprecated since NiFi 1.14.0 and causes quite a few error logs.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [x] Append changelog with changes