### PR TITLE
make OpenShift compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 ### Added
+- [PR #292](https://github.com/konpyutaika/nifikop/pull/292) - **[Operator/NifiCluster]** Modify RBAC kubebuilder annotations so NiFiKop works on OpenShift
+- [PR #292](https://github.com/konpyutaika/nifikop/pull/292) - **[Helm Chart]** Add Parameter for RunAsUser for OpenShift
 
 ### Changed
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -134,6 +134,10 @@ rules:
   - nificlusters/finalizers
   verbs:
   - update
+  - create
+  - delete
+  - get
+  - patch
 - apiGroups:
   - nifi.konpyutaika.com
   resources:
@@ -160,6 +164,10 @@ rules:
   - nifidataflows/finalizers
   verbs:
   - update
+  - create
+  - delete
+  - get
+  - patch
 - apiGroups:
   - nifi.konpyutaika.com
   resources:

--- a/config/samples/openshift.yaml
+++ b/config/samples/openshift.yaml
@@ -1,0 +1,80 @@
+apiVersion: nifi.konpyutaika.com/v1
+kind: NifiCluster
+metadata:
+  name: simplenifi
+spec:
+  service:
+    headlessEnabled: true
+    labels:
+      cluster-name: simplenifi
+  zkAddress: "zookeeper.zookeeper:2181"
+  zkPath: /simplenifi
+  externalServices:
+    - metadata:
+        labels:
+          cluster-name: driver-simplenifi
+      name: driver-ip
+      spec:
+        portConfigs:
+          - internalListenerName: http
+            port: 8080
+        type: LoadBalancer
+  clusterImage: "quay.io/rhnclimocha/nifi:1.17.0"
+  initContainerImage: 'bash:5.2.2'
+  oneNifiNodePerNode: true
+  readOnlyConfig:
+    nifiProperties:
+      overrideConfigs: |
+        nifi.sensitive.props.key=thisIsABadSensitiveKeyPassword
+  pod:
+    labels:
+      cluster-name: simplenifi
+  nodeConfigGroups:
+    default_group:
+      runAsUser: 1000690000 # set an uid in your namespace range
+      fsGroup: 1000690000 # set an gid in your namespace range
+      imagePullPolicy: IfNotPresent
+      isNode: true
+      serviceAccountName: default
+      storageConfigs:
+        - mountPath: "/opt/nifi/nifi-current/logs"
+          name: logs
+          pvcSpec:
+            accessModes:
+              - ReadWriteOnce
+            storageClassName: "standard"
+            resources:
+              requests:
+                storage: 10Gi
+      resourcesRequirements:
+        limits:
+          cpu: "0.5"
+          memory: 2Gi
+        requests:
+          cpu: "0.5"
+          memory: 2Gi
+  nodes:
+    - id: 1
+      nodeConfigGroup: "default_group"
+    - id: 2
+      nodeConfigGroup: "default_group"
+  propagateLabels: true
+  nifiClusterTaskSpec:
+    retryDurationMinutes: 10
+  listenersConfig:
+    internalListeners:
+      - containerPort: 8080
+        type: http
+        name: http
+      - containerPort: 6007
+        type: cluster
+        name: cluster
+      - containerPort: 10000
+        type: s2s
+        name: s2s
+      - containerPort: 9090
+        type: prometheus
+        name: prometheus
+      - containerPort: 6342
+        type: load-balance
+        name: load-balance

--- a/controllers/nificluster_controller.go
+++ b/controllers/nificluster_controller.go
@@ -68,7 +68,7 @@ type NifiClusterReconciler struct {
 // +kubebuilder:rbac:groups="policy",resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=nifi.konpyutaika.com,resources=nificlusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=nifi.konpyutaika.com,resources=nificlusters/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=nifi.konpyutaika.com,resources=nificlusters/finalizers,verbs=update
+// +kubebuilder:rbac:groups=nifi.konpyutaika.com,resources=nificlusters/finalizers,verbs=get;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/nifidataflow_controller.go
+++ b/controllers/nifidataflow_controller.go
@@ -58,7 +58,7 @@ type NifiDataflowReconciler struct {
 
 // +kubebuilder:rbac:groups=nifi.konpyutaika.com,resources=nifidataflows,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=nifi.konpyutaika.com,resources=nifidataflows/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=nifi.konpyutaika.com,resources=nifidataflows/finalizers,verbs=update
+// +kubebuilder:rbac:groups=nifi.konpyutaika.com,resources=nifidataflows/finalizers,verbs=get;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/helm/nifikop/values.yaml
+++ b/helm/nifikop/values.yaml
@@ -29,6 +29,9 @@ resources:
     cpu: 1
     memory: 512Mi
 
+## RunAsUser for OpenShift compatibility
+runAsUser: 1000
+
 ## pod spec host aliases for the operator
 ## Ref: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
 hostAliases: []

--- a/site/docs/2_deploy_nifikop/2_customizable_install_with_helm.md
+++ b/site/docs/2_deploy_nifikop/2_customizable_install_with_helm.md
@@ -55,6 +55,7 @@ The following tables lists the configurable parameters of the NiFi Operator Helm
 | `serviceAccount.create`          | Whether the SA creation is delegated to the chart or not                                                                                                                             | `true`                                      |
 | `serviceAccount.name`            | Name of the SA used for NiFiKop deployment                                                                                                                                           | release name                                |
 | `webhook.enabled`                | Enable webhook migration                                                                                                                                                 | `true`                                      |
+| `runAsUser` | Specify RunAsUser uid for NiFiKop operator pod | `1000` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/site/docs/3_manage_nifi/1_manage_clusters/1_deploy_cluster/1_quick_start.md
+++ b/site/docs/3_manage_nifi/1_manage_clusters/1_deploy_cluster/1_quick_start.md
@@ -64,3 +64,55 @@ And after you can deploy a simple NiFi cluster.
 # Add your zookeeper svc name to the configuration
 kubectl create -n nifi -f config/samples/simplenificluster.yaml
 ```
+
+### On OpenShift
+#### Install Zookeeper
+
+We need to get the uid/gid for the RunAsUser and the fsGroup for the namespace we deploy zookeeper in.
+
+Get the zookeeper allowed uid/gid.
+
+```bash
+zookeper_uid=$(kubectl get namespace zookeeper -o=jsonpath='{.metadata.annotations.openshift\.io/sa\.scc\.supplemental-groups}' | sed 's/\/10000$//' | tr -d '[:space:]')
+```
+Specify the runAsUser and fsGroup Parameter on install of zookeeper.
+
+```bash
+helm install zookeeper bitnami/zookeeper \
+    --set resources.requests.memory=256Mi \
+    --set resources.requests.cpu=250m \
+    --set resources.limits.memory=256Mi \
+    --set resources.limits.cpu=250m \
+    --set global.storageClass=standard \
+    --set networkPolicy.enabled=true \
+    --set replicaCount=3 \
+    --set containerSecurityContext.runAsUser=$zookeper_uid \
+    --set podSecurityContext.fsGroup=$zookeper_uid
+```
+
+#### Deploy NiFi cluster
+
+And after you can deploy a simple NiFi cluster.
+
+```bash
+# Add your zookeeper svc name to the configuration
+kubectl create -n nifi -f config/samples/simplenificluster.yaml
+### On OpenShift
+
+We need to get the uid/gid for the RunAsUser and the fsGroup for the namespace we deploy our nificluster in.
+
+```bash
+uid=$(kubectl get namespace nifi -o=jsonpath='{.metadata.annotations.openshift\.io/sa\.scc\.supplemental-groups}' | sed 's/\/10000$//' | tr -d '[:space:]')
+```
+
+Then update the config/samples/openshift file with our uid value.
+
+```bash
+sed -i "s/1000690000/$uid/g" config/samples/openshift.yaml
+```
+
+And after you can deploy a simple NiFi cluster.
+
+```bash
+kubectl create -n nifi -f config/samples/openshift.yaml
+```


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | yes|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | mentioned in #250 
| License         | Apache 2.0


### What's in this PR?
1. I updated the kubebuilder RBAC annotations so the operator works on OpenShift.
2. I added a new variable to install the helm operator while specifying the RunAsUser
3. I added a nificlusters.nifi.konpyutaika.com sample for OpenShift 


### Why?
As it is NifiKop does not run on OpenShift without custom day 2 modifications


### Additional context
I checked the install on OpenShift
```bash
# Tried on a clean AKS OpenShift cluster
oc version  
Client Version: 4.12.9
Kustomize Version: v4.5.7
Server Version: 4.10.54
Kubernetes Version: v1.23.12+8a6bfe4
# Create namespaces for Zookeeper and NiFi
oc create ns zookeeper
oc create ns nifi

# Install the CustomResourceDefinitions and cert-manager itself
kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.7.2/cert-manager.yaml

# Get UID range for the operator install from the nifi namespace
uid=$(kubectl get namespace nifi -o=jsonpath='{.metadata.annotations.openshift\.io/sa\.scc\.supplemental-groups}' | sed 's/\/10000$//' | tr -d '[:space:]')

# Install Nifi operator using helm
helm install nifikop \
    nifikop \
    --namespace=nifi \
    --version 1.1.1 \
    --set image.tag=v1.1.1-release \
    --set resources.requests.memory=256Mi \
    --set resources.requests.cpu=250m \
    --set resources.limits.memory=256Mi \
    --set resources.limits.cpu=250m \
    --set namespaces={"nifi"} \
    --set runAsUser=$uid

# Get UID range for the Zookeeper operator from the zookeeper namespace
zookeper_uid=$(kubectl get namespace zookeeper -o=jsonpath='{.metadata.annotations.openshift\.io/sa\.scc\.supplemental-groups}' | sed 's/\/10000$//' | tr -d '[:space:]')

# Get the default storage class for the cluster
sc=$(kubectl get storageclass -o=jsonpath='{range .items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")]}{.metadata.name}{end}')

# Install Zookeeper using helm
helm install zookeeper bitnami/zookeeper \
    --set resources.requests.memory=256Mi \
    --set resources.requests.cpu=250m \
    --set resources.limits.memory=256Mi \
    --set resources.limits.cpu=250m \
    --set global.storageClass=$sc \
    --set networkPolicy.enabled=true \
    --set replicaCount=3 \
    --set containerSecurityContext.runAsUser=$zookeper_uid \
    --set podSecurityContext.fsGroup=$zookeper_uid \
    --namespace zookeeper

# Use the UID for the NiFi operator to set the fsGroup and runAsUser
sed -i "s/1000690000/$uid/g" config/samples/openshift

# Use the default storage class for the cluster to set the persistent volume claim
sed -i "s/standard/$sc/g" config/samples/openshift

# Apply the configuration for the NiFi operator
oc apply -f config/samples/openshift -n nifi

# Expose the NiFi service as a route
oc expose svc -n nifi simplenifi-headless

# Get the route for the NiFi service
route=$(kubectl get route simplenifi-headless -n nifi -o=jsonpath='{.spec.host}')

# Open the NiFi UI in Firefox using the route
firefox http://$route/nifi

```


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] User guide and development docs updated (if needed) 
- [x] Append changelog with changes

### To Do
- [x] User guide and development docs updated