### PR TITLE
Set default namespace in NifiNodeGroupAutoscaler's clusterRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed Bugs
 
+- [PR #302](https://github.com/konpyutaika/nifikop/pull/302) - **[Operator/NifiNodeGroupAutoscaler]** Set default namespace in NifiNodeGroupAutoscaler's clusterRef.
+
 ### Deprecated
 
 ### Removed

--- a/controllers/nifinodegroupautoscaler_controller.go
+++ b/controllers/nifinodegroupautoscaler_controller.go
@@ -103,15 +103,17 @@ func (r *NifiNodeGroupAutoscalerReconciler) Reconcile(ctx context.Context, req c
 
 	// lookup NifiCluster reference
 	// we do not want cached objects here. We want an accurate state of what the cluster is right now, so bypass the client cache by using the APIReader directly.
+	clusterRef := nodeGroupAutoscaler.Spec.ClusterRef
+	clusterRef.Namespace = GetClusterRefNamespace(nodeGroupAutoscaler.Namespace, clusterRef)
 	cluster := &v1.NifiCluster{}
 	err = r.APIReader.Get(ctx,
 		types.NamespacedName{
-			Name:      nodeGroupAutoscaler.Spec.ClusterRef.Name,
-			Namespace: nodeGroupAutoscaler.Spec.ClusterRef.Namespace,
+			Name:      clusterRef.Name,
+			Namespace: clusterRef.Namespace,
 		},
 		cluster)
 	if err != nil {
-		return RequeueWithError(r.Log, fmt.Sprintf("failed to look up cluster reference %v+", nodeGroupAutoscaler.Spec.ClusterRef), err)
+		return RequeueWithError(r.Log, fmt.Sprintf("failed to look up cluster reference %v+", clusterRef), err)
 	}
 
 	// Determine how many replicas there currently are and how many are desired for the appropriate node group


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Set default namespace in `NifiNodeGroupAutoscaler`'s clusterRef if none is provided.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
All the other resources of NiFiKop are working like that and it was allowed to do so but it caused an error.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [x] Append changelog with changes