### PR TITLE
Fix update registry uri that was not working in NiFi 1.23.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed Bugs
 
 - [PR #302](https://github.com/konpyutaika/nifikop/pull/302) - **[Operator/NifiNodeGroupAutoscaler]** Set default namespace in NifiNodeGroupAutoscaler's clusterRef.
+- [PR #305](https://github.com/konpyutaika/nifikop/pull/305) - **[Operator/NifiRegistryClient]** Registry client URI can't be updated.
 
 ### Deprecated
 

--- a/pkg/clientwrappers/registryclient/registryclient.go
+++ b/pkg/clientwrappers/registryclient/registryclient.go
@@ -127,7 +127,10 @@ func updateRegistryClientEntity(registryClient *v1.NifiRegistryClient, entity *n
 		entity.Component = &nigoapi.FlowRegistryClientDto{}
 	}
 
+	entity.Component.Properties = make(map[string]string)
+
 	entity.Component.Name = registryClient.Name
 	entity.Component.Description = registryClient.Spec.Description
 	entity.Component.Uri = registryClient.Spec.Uri
+	entity.Component.Properties["url"] = registryClient.Spec.Uri
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fix to enable the operator to update a client registry in recent versions of NiFi (1.23.2).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [x] Append changelog with changes