### PR TITLE
[Feature/NifiCluster] Add ability to set container port network protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- [PR #320](https://github.com/konpyutaika/nifikop/pull/320) - **[Operator/NifiCluster]** Added ability to set NiFi container port protocol via `InternalListenersConfig`.
+
 ### Changed
 
 - [PR #307](https://github.com/konpyutaika/nifikop/pull/307) - **[Operator]** Upgrade golang to 1.21.2.

--- a/api/v1/nificluster_types.go
+++ b/api/v1/nificluster_types.go
@@ -445,10 +445,8 @@ type InternalListenerConfig struct {
 	Name string `json:"name"`
 	// The container port.
 	ContainerPort int32 `json:"containerPort"`
-	// +kubebuilder:validation:Enum:={"TCP", "UDP", "SCTP"}
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:default:="TCP"
 	// The network protocol for this listener. Options defined here: https://pkg.go.dev/k8s.io/api/core/v1#Protocol
+	// +kubebuilder:validation:Enum={"TCP", "UDP", "SCTP"}
 	Protocol corev1.Protocol `json:"protocol,omitempty"`
 }
 

--- a/api/v1/nificluster_types.go
+++ b/api/v1/nificluster_types.go
@@ -445,7 +445,8 @@ type InternalListenerConfig struct {
 	Name string `json:"name"`
 	// The container port.
 	ContainerPort int32 `json:"containerPort"`
-	// +kubebuilder:validation:Enum={"TCP", "UDP", "SCTP"}
+	// +kubebuilder:validation:Enum:={"TCP", "UDP", "SCTP"}
+	// +kubebuilder:default:="TCP"
 	// The network protocol for this listener. Options defined here: https://pkg.go.dev/k8s.io/api/core/v1#Protocol
 	Protocol corev1.Protocol `json:"protocol,omitempty"`
 }

--- a/api/v1/nificluster_types.go
+++ b/api/v1/nificluster_types.go
@@ -446,7 +446,8 @@ type InternalListenerConfig struct {
 	// The container port.
 	ContainerPort int32 `json:"containerPort"`
 	// +kubebuilder:validation:Enum:={"TCP", "UDP", "SCTP"}
-	// +kubebuilder:default:="TCP"
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:default:="TCP"
 	// The network protocol for this listener. Options defined here: https://pkg.go.dev/k8s.io/api/core/v1#Protocol
 	Protocol corev1.Protocol `json:"protocol,omitempty"`
 }

--- a/api/v1/nificluster_types.go
+++ b/api/v1/nificluster_types.go
@@ -445,6 +445,9 @@ type InternalListenerConfig struct {
 	Name string `json:"name"`
 	// The container port.
 	ContainerPort int32 `json:"containerPort"`
+	// +kubebuilder:validation:Enum={"TCP", "UDP", "SCTP"}
+	// The network protocol for this listener. Options defined here: https://pkg.go.dev/k8s.io/api/core/v1#Protocol
+	Protocol corev1.Protocol `json:"protocol,omitempty"`
 }
 
 type ExternalServiceConfig struct {

--- a/api/v1/nificluster_types_test.go
+++ b/api/v1/nificluster_types_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -47,5 +48,30 @@ func TestGetCreationTimeOrderedNodes(t *testing.T) {
 	}
 	if nodeList[0].Id != 2 || nodeList[1].Id != 4 || nodeList[2].Id != 3 || nodeList[3].Id != 5 {
 		t.Errorf("Incorrect node list: %v+", nodeList)
+	}
+}
+
+func TestListenersConfig(t *testing.T) {
+	cluster := &NifiCluster{
+		Spec: NifiClusterSpec{
+			Nodes: []Node{
+				{Id: 2, NodeConfigGroup: "scale-group", Labels: map[string]string{"scale_me": "true"}},
+				{Id: 3, NodeConfigGroup: "scale-group", Labels: map[string]string{"scale_me": "true"}},
+				{Id: 4, NodeConfigGroup: "scale-group", Labels: map[string]string{"scale_me": "true"}},
+				{Id: 5, NodeConfigGroup: "other-group", Labels: map[string]string{"other_group": "true"}},
+			},
+			ListenersConfig: &ListenersConfig{
+				InternalListeners: []InternalListenerConfig{
+					{
+						Name:     "foo",
+						Protocol: corev1.ProtocolTCP,
+					},
+				},
+			},
+		},
+	}
+
+	if cluster.Spec.ListenersConfig.InternalListeners[0].Protocol != "" {
+		t.Errorf("incorrect protocol")
 	}
 }

--- a/api/v1/nificluster_types_test.go
+++ b/api/v1/nificluster_types_test.go
@@ -50,33 +50,3 @@ func TestGetCreationTimeOrderedNodes(t *testing.T) {
 		t.Errorf("Incorrect node list: %v+", nodeList)
 	}
 }
-
-func TestListenersConfig(t *testing.T) {
-	cluster := &NifiCluster{
-		Spec: NifiClusterSpec{
-			Nodes: []Node{
-				{Id: 2, NodeConfigGroup: "scale-group", Labels: map[string]string{"scale_me": "true"}},
-				{Id: 3, NodeConfigGroup: "scale-group", Labels: map[string]string{"scale_me": "true"}},
-				{Id: 4, NodeConfigGroup: "scale-group", Labels: map[string]string{"scale_me": "true"}},
-				{Id: 5, NodeConfigGroup: "other-group", Labels: map[string]string{"other_group": "true"}},
-			},
-			ListenersConfig: &ListenersConfig{
-				InternalListeners: []InternalListenerConfig{
-					{
-						Name:     "foo",
-					},
-				},
-			},
-		},
-	}
-
-	// assert blank by default
-	if cluster.Spec.ListenersConfig.InternalListeners[0].Protocol != "" {
-		t.Errorf("incorrect protocol")
-	}
-	// set protocol
-	cluster.Spec.ListenersConfig.InternalListeners[0].Protocol = corev1.ProtocolUDP
-	if cluster.Spec.ListenersConfig.InternalListeners[0].Protocol != corev1.ProtocolUDP {
-		t.Errorf("incorrect protocol. Should have been UDP")
-	}
-}

--- a/api/v1/nificluster_types_test.go
+++ b/api/v1/nificluster_types_test.go
@@ -64,14 +64,19 @@ func TestListenersConfig(t *testing.T) {
 				InternalListeners: []InternalListenerConfig{
 					{
 						Name:     "foo",
-						Protocol: corev1.ProtocolTCP,
 					},
 				},
 			},
 		},
 	}
 
+	// assert blank by default
 	if cluster.Spec.ListenersConfig.InternalListeners[0].Protocol != "" {
 		t.Errorf("incorrect protocol")
+	}
+	// set protocol
+	cluster.Spec.ListenersConfig.InternalListeners[0].Protocol = corev1.ProtocolUDP
+	if cluster.Spec.ListenersConfig.InternalListeners[0].Protocol != corev1.ProtocolUDP {
+		t.Errorf("incorrect protocol. Should have been UDP")
 	}
 }

--- a/api/v1/nificluster_types_test.go
+++ b/api/v1/nificluster_types_test.go
@@ -4,8 +4,7 @@ import (
 	"testing"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetCreationTimeOrderedNodes(t *testing.T) {

--- a/api/v1alpha1/nificluster_conversion.go
+++ b/api/v1alpha1/nificluster_conversion.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	v1 "github.com/konpyutaika/nifikop/api/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 )
 
@@ -353,6 +354,8 @@ func convertInternalListeners(src []InternalListenerConfig) []v1.InternalListene
 			Type:          srcInternalListenerConfig.Type,
 			Name:          srcInternalListenerConfig.Name,
 			ContainerPort: srcInternalListenerConfig.ContainerPort,
+			// default to TCP when converting from v1alpha1 to v1
+			Protocol: corev1.ProtocolTCP,
 		})
 	}
 

--- a/api/v1alpha1/nificluster_conversion_test.go
+++ b/api/v1alpha1/nificluster_conversion_test.go
@@ -204,7 +204,9 @@ func internalListenersConfigsEqual(lc1 []InternalListenerConfig, lc2 []v1.Intern
 	for i, lc := range lc1 {
 		if lc.ContainerPort != lc2[i].ContainerPort ||
 			lc.Name != lc2[i].Name ||
-			lc.Type != lc2[i].Type {
+			lc.Type != lc2[i].Type ||
+			// this protocol assertion verifies the default gets set properly
+			lc2[i].Protocol != corev1.ProtocolTCP {
 			return false
 		}
 	}

--- a/config/crd/bases/nifi.konpyutaika.com_nificlusters.yaml
+++ b/config/crd/bases/nifi.konpyutaika.com_nificlusters.yaml
@@ -737,9 +737,7 @@ spec:
                         name:
                           type: string
                         protocol:
-                          allOf:
-                          - default: TCP
-                          - default: TCP
+                          default: TCP
                           enum:
                           - TCP
                           - UDP

--- a/config/crd/bases/nifi.konpyutaika.com_nificlusters.yaml
+++ b/config/crd/bases/nifi.konpyutaika.com_nificlusters.yaml
@@ -736,6 +736,13 @@ spec:
                           type: integer
                         name:
                           type: string
+                        protocol:
+                          default: TCP
+                          enum:
+                          - TCP
+                          - UDP
+                          - SCTP
+                          type: string
                         type:
                           enum:
                           - cluster

--- a/config/crd/bases/nifi.konpyutaika.com_nificlusters.yaml
+++ b/config/crd/bases/nifi.konpyutaika.com_nificlusters.yaml
@@ -737,7 +737,9 @@ spec:
                         name:
                           type: string
                         protocol:
-                          default: TCP
+                          allOf:
+                          - default: TCP
+                          - default: TCP
                           enum:
                           - TCP
                           - UDP

--- a/helm/nifikop/crds/nifi.konpyutaika.com_nificlusters.yaml
+++ b/helm/nifikop/crds/nifi.konpyutaika.com_nificlusters.yaml
@@ -737,9 +737,7 @@ spec:
                         name:
                           type: string
                         protocol:
-                          allOf:
-                          - default: TCP
-                          - default: TCP
+                          default: TCP
                           enum:
                           - TCP
                           - UDP

--- a/helm/nifikop/crds/nifi.konpyutaika.com_nificlusters.yaml
+++ b/helm/nifikop/crds/nifi.konpyutaika.com_nificlusters.yaml
@@ -736,6 +736,13 @@ spec:
                           type: integer
                         name:
                           type: string
+                        protocol:
+                          default: TCP
+                          enum:
+                          - TCP
+                          - UDP
+                          - SCTP
+                          type: string
                         type:
                           enum:
                           - cluster

--- a/helm/nifikop/crds/nifi.konpyutaika.com_nificlusters.yaml
+++ b/helm/nifikop/crds/nifi.konpyutaika.com_nificlusters.yaml
@@ -737,7 +737,9 @@ spec:
                         name:
                           type: string
                         protocol:
-                          default: TCP
+                          allOf:
+                          - default: TCP
+                          - default: TCP
                           enum:
                           - TCP
                           - UDP

--- a/pkg/resources/nifi/pod.go
+++ b/pkg/resources/nifi/pod.go
@@ -267,11 +267,14 @@ func generatePodAntiAffinity(clusterName string, hardRuleEnabled bool) *corev1.P
 
 func (r *Reconciler) generateContainerPortForInternalListeners() []corev1.ContainerPort {
 	var usedPorts []corev1.ContainerPort
-
 	for _, iListeners := range r.NifiCluster.Spec.ListenersConfig.InternalListeners {
+		protocol := iListeners.Protocol
+		if protocol == "" {
+			protocol = corev1.ProtocolTCP
+		}
 		usedPorts = append(usedPorts, corev1.ContainerPort{
 			Name:          strings.ReplaceAll(iListeners.Name, "_", ""),
-			Protocol:      corev1.ProtocolTCP,
+			Protocol:      protocol,
 			ContainerPort: iListeners.ContainerPort,
 		})
 	}

--- a/site/docs/5_references/1_nifi_cluster/6_listeners_config.md
+++ b/site/docs/5_references/1_nifi_cluster/6_listeners_config.md
@@ -24,6 +24,9 @@ ListenersConfig defines the Nifi listener types :
       - type: "load-balance"
         name: "load-balance"
         containerPort: 6342
+      - name: "my-custom-listener-port"
+        containerPort: 1234
+        protocol: "TCP"
     sslSecrets:
       tlsSecretName: "test-nifikop"
       create: true
@@ -45,6 +48,7 @@ Field|Type|Description|Required|Default|
 |type|enum{ "cluster", "http", "https", "s2s", "prometheus", "load-balance"}| allow to specify if we are in a specific nifi listener it's allowing to define some required information such as Cluster Port, Http Port, Https Port, S2S, Load Balance port, or Prometheus port| Yes | - |
 |name|string| an identifier for the port which will be configured. | Yes | - |
 |containerPort|int32| the containerPort. | Yes | - |
+|protocol|[Protocol](https://pkg.go.dev/k8s.io/api/core/v1#Protocol)| the network protocol for this listener. Must be one of the protocol enum values (i.e. TCP, UDP, SCTP).  | No | `TCP` |
 
 
 ## SSLSecrets


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #319
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Adds the ability to set the NiFi container port network protocol. This field is new and optional, defaulting to `TCP`. If one wished to set the protocol for all container ports, you would use the following:

```yaml
  listenersConfig:
    internalListeners:
      - type: "https"
        name: "https"
        containerPort: 8443
        protocol: "TCP"
      - type: "cluster"
        name: "cluster"
        containerPort: 6007
        protocol: "TCP"
      - type: "s2s"
        name: "s2s"
        containerPort: 10000
        protocol: "TCP"
      - type: "prometheus"
        name: "prometheus"
        containerPort: 9090
        protocol: "TCP"
      - type: "load-balance"
        name: "load-balance"
        containerPort: 6342
        protocol: "TCP"
      - name: "my-custom-listener-port"
        containerPort: 1234
        protocol: "UDP"
    sslSecrets:
      tlsSecretName: "test-nifikop"
      create: true
```

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

It's not currently possible to set anything other than TCP.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
