### PR TITLE
upgrade golang to 1.21.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ orbs:
     executors:
       operator-build:
         docker:
-          - image: ghcr.io/konpyutaika/docker-images/nifikop-build:1.21.3
+          - image: ghcr.io/konpyutaika/docker-images/nifikop-build:1.21.4
     # Define jobs list
     jobs:
       # Build job, which build operator docker image (with operator-sdk build)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [PR #307](https://github.com/konpyutaika/nifikop/pull/307) - **[Operator]** Upgrade golang to 1.21.2.
 - [PR #314](https://github.com/konpyutaika/nifikop/pull/314) - **[Operator]** Upgrade golang to 1.21.3.
 - [PR #314](https://github.com/konpyutaika/nifikop/pull/314) - **[Documentation]** Upgrade node 20.9.0, Docusaurus 3, React 18 and other dependencies.
+- [PR #321](https://github.com/konpyutaika/nifikop/pull/321) - **[Operator]** Upgrade golang to 1.21.4.
 
 ### Fixed Bugs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.21.3 as builder
+FROM golang:1.21.4 as builder
 
 WORKDIR /workspace
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DOCKER_REGISTRY_BASE 	?= ghcr.io/konpyutaika/docker-images
 IMAGE_TAG				?= $(shell git describe --tags --abbrev=0 --match '[0-9].*[0-9].*[0-9]' 2>/dev/null)
 IMAGE_NAME 				?= $(SERVICE_NAME)
 BUILD_IMAGE				?= ghcr.io/konpyutaika/docker-images/nifikop-build
-GOLANG_VERSION          ?= 1.21.3
+GOLANG_VERSION          ?= 1.21.4
 IMAGE_TAG_BASE ?= <registry>/<operator name>
 OS = $(shell go env GOOS)
 ARCH = $(shell go env GOARCH)


### PR DESCRIPTION
### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

upgrade golang to 1.21.4. Requires new build image pushed.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Unit tests failing due to vulnerability in golang 1.21.3: https://app.circleci.com/pipelines/github/konpyutaika/nifikop/1065/workflows/e7f6c75d-eac6-4553-846a-936d28c8ad35/jobs/2693

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
