### PR TITLE
SingleUserConfiguration block in Helm chart refers to incorrect value…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed Bugs
 
 - [PR #311](https://github.com/konpyutaika/nifikop/pull/311) - **[Operator/NifiConnection]** Doesn't have its own requeue interval.
+- [PR #322](https://github.com/konpyutaika/nifikop/pull/322) - **[Helm Chart]** SingleUserConfiguration block in Helm chart refers to incorrect values and has incorrect indentation.
 
 ### Deprecated
 

--- a/helm/nifi-cluster/templates/nifi-cluster.yaml
+++ b/helm/nifi-cluster/templates/nifi-cluster.yaml
@@ -24,16 +24,16 @@ spec:
   {{ end }}
   singleUserConfiguration:
     {{ if .Values.cluster.singleUserConfiguration.enabled }}
-      enabled: {{ .Values.cluster.enabled }}
+      enabled: {{ .Values.cluster.singleUserConfiguration.enabled }}
     {{ end }}
     {{ if .Values.cluster.singleUserConfiguration.secretRef }}
-      secretRef: {{ toYaml .Values.cluster.singleUserConfiguration.secretRef | nindent 6 }}
+      secretRef: {{ toYaml .Values.cluster.singleUserConfiguration.secretRef | nindent 8 }}
     {{ end }}
     {{ if .Values.cluster.singleUserConfiguration.secretKeys }}
-      secretKeys: {{ toYaml .Values.cluster.singleUserConfiguration.secretKeys | nindent 6 }}
+      secretKeys: {{ toYaml .Values.cluster.singleUserConfiguration.secretKeys | nindent 8 }}
     {{ end }}
     {{ if .Values.cluster.singleUserConfiguration.authorizerEnabled }}
-      authorizerEnabled: {{ .Values.cluster.authorizerEnabled }}
+      authorizerEnabled: {{ .Values.cluster.singleUserConfiguration.authorizerEnabled }}
     {{ end }}
   zkAddress: {{ .Values.cluster.zkAddress }}
   zkPath: {{ .Values.cluster.zkPath }}


### PR DESCRIPTION
…s and has incorrect indentation

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/konpyutaika/nifikop/issues/318
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fix in Helm chart to correct singleUserConfiguration block

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The indentation in it are incorrect and some value references too. It impossible de configure it.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [x] Append changelog with changes