### PR TITLE
Add golangci linter to project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,21 @@ orbs:
               paths:
                 - build/_output
                 - vendor
-
+      lint:
+        <<: *params_operator
+        <<: *job_operator
+        steps:
+          - checkout:
+              path: /home/circleci/nifikop
+          - setup_remote_docker # Creates a separate environment for each build for security.
+          - restore_cache: # If exist, restore dependencies libs download cache, from previous pipeline execution.
+              keys: # Use checksum of go.sum to version cache.
+                - << parameters.operatorName >>-build-{{ .Branch }}-{{ checksum "go.sum" }}-{{ .Environment.CACHE_VERSION }}
+          - attach_workspace: # Attach artifact from workdir
+              at: /home/circleci
+          - run:
+              name: Lint Code
+              command: make lint-warn # currently only do lint warn
       # Build job, which builds the cross-platform operator docker image (with operator-sdk build)
       build-operator:
         <<: *params_operator
@@ -277,10 +291,16 @@ workflows:
           name: generate-nifikop
           <<: *everytime_filter
 
+      - operator/lint:
+          name: lint-nifikop
+          requires:
+            - generate-nifikop
+          <<: *everytime_filter
+
       - operator/test-unit:
           name: unit-test-nifikop
           requires:
-            - generate-nifikop
+            - lint-nifikop
           <<: *everytime_filter
 
       - operator/build-operator:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ orbs:
               at: /home/circleci
           - run:
               name: Lint Code
-              command: make lint-warn # currently only do lint warn
+              command: make lint
       # Build job, which builds the cross-platform operator docker image (with operator-sdk build)
       build-operator:
         <<: *params_operator

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,114 @@
+run:
+  timeout: 10m
+
+linters-settings:
+  gci:
+    local-prefixes: github.com/konpyutaika/nifikop
+  goconst:
+    min-len: 3
+    min-occurrences: 3
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - dupImport
+      - ifElseChain
+      - octalLiteral
+      - whyNoLint
+      - wrapperFunc
+      - importShadow
+      - unnamedResult
+      - unnecessaryBlock
+    settings:
+      rangeValCopy:
+        sizeThreshold: 512
+      hugeParam:
+        sizeThreshold: 512
+  gocyclo:
+    min-complexity: 16
+  goheader:
+    template-path: ./hack/boilerplate.go.txt
+  dupl:
+    threshold: 200
+  govet:
+    check-shadowing: false
+  lll:
+    line-length: 300
+  misspell:
+    locale: US
+
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - bodyclose
+    - dogsled
+    - errcheck
+    - errorlint
+    - exhaustive
+    - exportloopref
+    - gci
+    - goconst
+    - gocritic
+    - godot
+    - gofmt
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nolintlint
+    - prealloc
+    - revive
+    - staticcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - whitespace
+
+issues:
+  # Excluding configuration per-path and per-linter
+  exclude-rules:
+    # Exclude some linters from running on tests files.
+    - path: _test(ing)?\.go
+      linters:
+        - gocyclo
+        - errcheck
+        - dupl
+        - gosec
+        - unparam
+        - lll
+
+    # Ease some gocritic warnings on test files.
+    - path: _test\.go
+      text: "(unnamedResult|exitAfterDefer)"
+      linters:
+        - gocritic
+
+    # This is a "potential hardcoded credentials" warning. It's triggered by
+    # any variable with 'secret' in the same, and thus hits a lot of false
+    # positives in Kubernetes land where a Secret is an object type.
+    - text: "G101:"
+      linters:
+        - gosec
+
+    # The header check doesn't correctly parse the header as a code comment and is
+    # triggered by the perceived diff. The header check still correctly detects missing
+    # license headers and is useful for some cases.
+    - text: "Actual:"
+      linters:
+        - goheader
+
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ This document might contain links to known issues, another good reason to take a
 This is a rough outline of what a contributor's workflow looks like:
 
 - Create a topic branch from where to base the contribution. This is usually master.
+- Run `make fmt` to fix any linting issues in your changes.
 - Make commits of logical units.
 - Make sure commit messages are in the proper format (see below).
 - Push changes in a topic branch to a personal fork of the repository.

--- a/Makefile
+++ b/Makefile
@@ -155,10 +155,9 @@ lint: golangci-lint
 
 # Run go fmt against code
 .PHONY: fmt
-fmt: golangci-lint ## Ensure consistent code style
+fmt:
 	@go mod tidy
 	@go fmt ./...
-	@$(GOLANGCI_LINT) run --fix --issues-exit-code $(GOLANGCI_EXIT_CODE)
 
 # RUN https://go.dev/blog/vuln against code for known CVEs
 .PHONY: govuln
@@ -169,11 +168,11 @@ govuln:
 # Run tests
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 .PHONY: test
-test: manifests generate fmt govuln envtest
+test: manifests generate fmt lint govuln envtest
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
 
 .PHONY: test-with-vendor
-test-with-vendor: manifests generate fmt govuln envtest
+test-with-vendor: manifests generate fmt lint govuln envtest
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -mod=vendor ./... -coverprofile cover.out
 
 # Run against the configured Kubernetes cluster in ~/.kube/config

--- a/docker/build-image/Dockerfile
+++ b/docker/build-image/Dockerfile
@@ -1,4 +1,5 @@
 ARG GOLANG_VERSION
+ARG GOLANGCI_VERSION
 
 FROM docker as docker-base
 COPY --from=docker/buildx-bin:latest /buildx /usr/libexec/docker/cli-plugins/docker-buildx
@@ -73,7 +74,7 @@ RUN curl -sSL https://github.com/gotestyourself/gotestsum/releases/download/v0.3
   tar -xz -C /usr/local/bin gotestsum
 
 # Install official golang CI linter
-RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.49.0
+RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v${GOLANGCI_VERSION}
 
 # Install kubectl cli
 RUN curl -L https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl  \


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR adds the configuration for golangci-lint into the repository and also configures the `Makefile` to use the linter with `lint` and `fmt` options. The CircleCI config is also updated to use the linter everytime, currently it is configured to only output issues in linting without failing with exit code 1 i.e. it calls `make lint-warn`

### Links
- golangci-lint: https://golangci-lint.run/
- Initial config from External Secrets repo: https://github.com/external-secrets/external-secrets/blob/eea369578d0d715af3962f92c08cb26685acf3eb/.golangci.yaml

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] User guide and development docs updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] Switch `make fmt` to also not exit with error until all linting issues are fixed