### PR TITLE
update PVC annotations when storage config annotations are updated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Fixed Bugs
 
+- [PR #336](https://github.com/konpyutaika/nifikop/pull/336) - **[Operator/NifiCluster]** Fixed issue where nifikop wouldn't update `storageConfigs.metadata.annotations` if they were changed after initial creation. 
+
 ### Deprecated
 
 ### Removed

--- a/pkg/resources/nifi/nifi.go
+++ b/pkg/resources/nifi/nifi.go
@@ -538,9 +538,11 @@ func (r *Reconciler) reconcileNifiPVC(log zap.Logger, desiredPVC *corev1.Persist
 			}
 			resReq := desiredPVC.Spec.Resources.Requests
 			labels := desiredPVC.Labels
+			annotations := desiredPVC.Annotations
 			desiredPVC = currentPVC.DeepCopy()
 			desiredPVC.Spec.Resources.Requests = resReq
 			desiredPVC.Labels = labels
+			desiredPVC.Annotations = annotations
 
 			if err := r.Client.Update(context.TODO(), desiredPVC); err != nil {
 				return errorfactory.New(errorfactory.APIFailure{}, err, "updating resource failed", "kind", desiredType)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #332 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

When `storageConfigs.metadata.annotations` are updated, nifikop fails to update the annotations for the PVCs it owns. It will only apply them once on creation and then never again. This PR fixes that, so updates are properly reflected.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

It's not possible to update existing PVC annotations.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
