### PR TITLE
Unschedule the whole dataflow in case of ParameterContext reference u…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- [PR #340](https://github.com/konpyutaika/nifikop/pull/340) - **[Operator/NifiDataflow]** Updated the logic to stop the entire dataflow instead of just the processors when the parameter context reference is updated.
+
 ### Fixed Bugs
 
 ### Deprecated

--- a/pkg/clientwrappers/dataflow/dataflow.go
+++ b/pkg/clientwrappers/dataflow/dataflow.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	nigoapi "github.com/konpyutaika/nigoapi/pkg/nifi"
+	"go.uber.org/zap"
 
 	v1 "github.com/konpyutaika/nifikop/api/v1"
 	"github.com/konpyutaika/nifikop/pkg/clientwrappers"
@@ -17,6 +18,11 @@ var log = common.CustomLogger().Named("dataflow-method")
 
 // DataflowExist check if the NifiDataflow exist on NiFi Cluster.
 func DataflowExist(flow *v1.NifiDataflow, config *clientconfig.NifiConfig) (bool, error) {
+	log.Debug("Checking existence of dataflow",
+		zap.String("clusterName", flow.Spec.ClusterRef.Name),
+		zap.String("flowId", flow.Spec.FlowId),
+		zap.String("dataflow", flow.Name))
+
 	if flow.Status.ProcessGroupID == "" {
 		return false, nil
 	}
@@ -78,6 +84,11 @@ func GetDataflowInformation(flow *v1.NifiDataflow, config *clientconfig.NifiConf
 // CreateDataflow will deploy the NifiDataflow on NiFi Cluster.
 func CreateDataflow(flow *v1.NifiDataflow, config *clientconfig.NifiConfig,
 	registry *v1.NifiRegistryClient) (*v1.NifiDataflowStatus, error) {
+	log.Debug("Creating dataflow",
+		zap.String("clusterName", flow.Spec.ClusterRef.Name),
+		zap.String("flowId", flow.Spec.FlowId),
+		zap.String("dataflow", flow.Name))
+
 	nClient, err := common.NewClusterConnection(log, config)
 	if err != nil {
 		return nil, err
@@ -134,6 +145,11 @@ func IsDataflowUnscheduled(flow *v1.NifiDataflow, config *clientconfig.NifiConfi
 
 // ScheduleDataflow will schedule the controller services and components of the NifiDataflow.
 func ScheduleDataflow(flow *v1.NifiDataflow, config *clientconfig.NifiConfig) error {
+	log.Debug("Scheduling dataflow",
+		zap.String("clusterName", flow.Spec.ClusterRef.Name),
+		zap.String("flowId", flow.Spec.FlowId),
+		zap.String("dataflow", flow.Name))
+
 	nClient, err := common.NewClusterConnection(log, config)
 	if err != nil {
 		return err
@@ -592,6 +608,11 @@ func prepareUpdatePG(flow *v1.NifiDataflow, config *clientconfig.NifiConfig) (*v
 }
 
 func RemoveDataflow(flow *v1.NifiDataflow, config *clientconfig.NifiConfig) (*v1.NifiDataflowStatus, error) {
+	log.Debug("Removing dataflow",
+		zap.String("clusterName", flow.Spec.ClusterRef.Name),
+		zap.String("flowId", flow.Spec.FlowId),
+		zap.String("dataflow", flow.Name))
+
 	// Prepare Dataflow
 	status, err := prepareUpdatePG(flow, config)
 	if err != nil {
@@ -625,6 +646,11 @@ func RemoveDataflow(flow *v1.NifiDataflow, config *clientconfig.NifiConfig) (*v1
 }
 
 func UnscheduleDataflow(flow *v1.NifiDataflow, config *clientconfig.NifiConfig) error {
+	log.Debug("Unscheduling dataflow",
+		zap.String("clusterName", flow.Spec.ClusterRef.Name),
+		zap.String("flowId", flow.Spec.FlowId),
+		zap.String("dataflow", flow.Name))
+
 	nClient, err := common.NewClusterConnection(log, config)
 	if err != nil {
 		return err

--- a/pkg/clientwrappers/dataflow/dataflow.go
+++ b/pkg/clientwrappers/dataflow/dataflow.go
@@ -293,12 +293,8 @@ func SyncDataflow(
 
 	processGroups = append(processGroups, *pGEntity)
 	if isParameterContextChanged(parameterContext, processGroups) {
-		// unschedule processors
-		_, err := nClient.UpdateFlowProcessGroup(nigoapi.ScheduleComponentsEntity{
-			Id:    flow.Status.ProcessGroupID,
-			State: "STOPPED",
-		})
-		if err := clientwrappers.ErrorUpdateOperation(log, err, "Stop flow"); err != nil {
+		// unschedule dataflow
+		if err := UnscheduleDataflow(flow, config); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
…pdate

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
In case of parameter context reference update, the operator will now unschedule the entire dataflow (stop the processors and disable the controller services) instead of just stopping the processors.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
When the parameter context was referenced by a controller service, it was impossible to change the reference because the operator could not detach the parameter context because it was in use.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [x] Append changelog with changes