### PR TITLE
Replace WGET logic with CURL logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - [PR #340](https://github.com/konpyutaika/nifikop/pull/340) - **[Operator/NifiDataflow]** Updated the logic to stop the entire dataflow instead of just the processors when the parameter context reference is updated.
+- [PR #342](https://github.com/konpyutaika/nifikop/pull/342) - **[Operator/NifiCluster]** Updated the logic to retrieve theIP address from hostname with `curl` instead of `wget`.
 
 ### Fixed Bugs
 

--- a/pkg/resources/nifi/pod.go
+++ b/pkg/resources/nifi/pod.go
@@ -508,7 +508,7 @@ do
 	echo "Found: $ipResolved, expecting: $POD_IP"
     sleep 5
 
-	ipResolved=$(wget --tries=1 -T 1 -O /dev/null %s  2>&1 | sed -n 3p| awk '{split($0,a,"|"); print a[2] }')
+	ipResolved=$(curl -v -4 -m 1 --connect-timeout 1 %s 2>&1 | grep -o 'Trying [0-9.]*' | awk '{print $2}' | head -n 1)
 	echo "Found : $ipResolved"
     if [[ "$ipResolved" == "$POD_IP" ]]; then
 		echo Ip match for $POD_IP


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Replace the logic to retrieve the IP address from the hostname before starting NiFi to use `curl` instead of `wget`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Starting `2.0.0-M1` is not available in the Docker image.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [x] Append changelog with changes