### PR TITLE
Change default LogLevel of NiFi to INFO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [PR #345](https://github.com/konpyutaika/nifikop/pull/345) - **[Helm Chart]** Added option to include `NodePort` with custom hosts in `webProxyHosts`.
 - [PR #349](https://github.com/konpyutaika/nifikop/pull/349) - **[Operator/NifiRegistryClient]** Set FlowRegistry type in RegistryClient creation.
 - [PR #350](https://github.com/konpyutaika/nifikop/pull/350) - **[Operator]** Remove optimistic lock on `Patch`.
+- [PR #352](https://github.com/konpyutaika/nifikop/pull/352) - **[Operator]** Changed default LogLevel of NiFi from `DEBUG` to `INFO`.
 
 ### Fixed Bugs
 

--- a/pkg/resources/templates/config/logback.xml.go
+++ b/pkg/resources/templates/config/logback.xml.go
@@ -104,7 +104,7 @@ var LogbackTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     <logger name="org.apache.curator.ConnectionState" level="OFF" />
     
     <!-- Logger for managing logging statements for nifi clusters. -->
-    <logger name="org.apache.nifi.cluster" level="DEBUG"/>
+    <logger name="org.apache.nifi.cluster" level="INFO"/>
 
     <!-- Logger for logging HTTP requests received by the web server. -->
     <logger name="org.apache.nifi.server.JettyServer" level="INFO"/>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Change of the default loglevel of NiFi from `DEBUG` to `INFO`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
There is no reason it should be to `DEBUG` as in NiFi it's `INFO`.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [x] Append changelog with changes