### PR TITLE
Update login_identity_providers.xml template for 2.0.0-M1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [PR #349](https://github.com/konpyutaika/nifikop/pull/349) - **[Operator/NifiRegistryClient]** Set FlowRegistry type in RegistryClient creation.
 - [PR #350](https://github.com/konpyutaika/nifikop/pull/350) - **[Operator]** Remove optimistic lock on `Patch`.
 - [PR #352](https://github.com/konpyutaika/nifikop/pull/352) - **[Operator]** Changed default LogLevel of NiFi from `DEBUG` to `INFO`.
+- [PR #354](https://github.com/konpyutaika/nifikop/pull/354) - **[Operator/NifiCluster]** Updated `login_identity_providers.xml` template for 2.0.0-M1.
 
 ### Fixed Bugs
 

--- a/pkg/resources/templates/config/login_identity_providers.go
+++ b/pkg/resources/templates/config/login_identity_providers.go
@@ -23,39 +23,40 @@ var LoginIdentityProvidersTemplate = `<?xml version="1.0" encoding="UTF-8" stand
 <loginIdentityProviders>
     <!--
         Identity Provider for users logging in with username/password against an LDAP server.
-        
+
         'Authentication Strategy' - How the connection to the LDAP server is authenticated. Possible
             values are ANONYMOUS, SIMPLE, LDAPS, or START_TLS.
-        
+
         'Manager DN' - The DN of the manager that is used to bind to the LDAP server to search for users.
         'Manager Password' - The password of the manager that is used to bind to the LDAP server to
             search for users.
-            
+
         'TLS - Keystore' - Path to the Keystore that is used when connecting to LDAP using LDAPS or START_TLS.
         'TLS - Keystore Password' - Password for the Keystore that is used when connecting to LDAP
             using LDAPS or START_TLS.
         'TLS - Keystore Type' - Type of the Keystore that is used when connecting to LDAP using
-            LDAPS or START_TLS (i.e. JKS or PKCS12).
+            LDAPS or START_TLS such as PKCS12.
         'TLS - Truststore' - Path to the Truststore that is used when connecting to LDAP using LDAPS or START_TLS.
         'TLS - Truststore Password' - Password for the Truststore that is used when connecting to
             LDAP using LDAPS or START_TLS.
         'TLS - Truststore Type' - Type of the Truststore that is used when connecting to LDAP using
-            LDAPS or START_TLS (i.e. JKS or PKCS12).
+            LDAPS or START_TLS such as PKCS12.
         'TLS - Client Auth' - Client authentication policy when connecting to LDAP using LDAPS or START_TLS.
             Possible values are REQUIRED, WANT, NONE.
         'TLS - Protocol' - Protocol to use when connecting to LDAP using LDAPS or START_TLS. (i.e. TLS,
             TLSv1.1, TLSv1.2, etc).
-        'TLS - Shutdown Gracefully' - Specifies whether the TLS should be shut down gracefully 
+        'TLS - Shutdown Gracefully' - Specifies whether the TLS should be shut down gracefully
             before the target context is closed. Defaults to false.
-            
+
         'Referral Strategy' - Strategy for handling referrals. Possible values are FOLLOW, IGNORE, THROW.
         'Connect Timeout' - Duration of connect timeout. (i.e. 10 secs).
         'Read Timeout' - Duration of read timeout. (i.e. 10 secs).
-       
+
         'Url' - Space-separated list of URLs of the LDAP servers (i.e. ldap://<hostname>:<port>).
         'User Search Base' - Base DN for searching for users (i.e. CN=Users,DC=example,DC=com).
         'User Search Filter' - Filter for searching for users against the 'User Search Base'.
             (i.e. sAMAccountName={0}). The user specified name is inserted into '{0}'.
+
         'Identity Strategy' - Strategy to identify users. Possible values are USE_DN and USE_USERNAME.
             The default functionality if this property is missing is USE_DN in order to retain
             backward compatibility. USE_DN will use the full DN of the user entry if possible.
@@ -88,7 +89,6 @@ var LoginIdentityProvidersTemplate = `<?xml version="1.0" encoding="UTF-8" stand
         <property name="Url">{{.LdapConfiguration.Url}}</property>
         <property name="User Search Base">{{.LdapConfiguration.SearchBase}}</property>
         <property name="User Search Filter">{{.LdapConfiguration.SearchFilter}}</property>
-        <property name="Identity Strategy">{{.LdapConfiguration.IdentityStrategy}}</property>
         <property name="Identity Strategy">{{or .LdapConfiguration.IdentityStrategy "USE_DN"}}</property>
         <property name="Authentication Expiration">12 hours</property>
     </provider>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Update of the `login_identity_providers.xml` template, to match the one in 2.0.0-M1.
Changed:
```xml
<property name="Identity Strategy">{{.LdapConfiguration.IdentityStrategy}}</property>
<property name="Identity Strategy">{{or .LdapConfiguration.IdentityStrategy "USE_DN"}}</property>
```
to
```xml
<property name="Identity Strategy">{{or .LdapConfiguration.IdentityStrategy "USE_DN"}}</property>
```

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
`<property name="Identity Strategy">{{.LdapConfiguration.IdentityStrategy}}</property>` removed because it doesn't make sense to have it when you have `<property name="Identity Strategy">{{or .LdapConfiguration.IdentityStrategy "USE_DN"}}</property>`. Because if `.LdapConfiguration.IdentityStrategy` is empty, you will have `USE_DN`  otherwise you will have the value of `.LdapConfiguration.IdentityStrategy`.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [x] Append changelog with changes