### PR TITLE
Update parameter value to null instead of delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [PR #352](https://github.com/konpyutaika/nifikop/pull/352) - **[Operator]** Changed default LogLevel of NiFi from `DEBUG` to `INFO`.
 - [PR #354](https://github.com/konpyutaika/nifikop/pull/354) - **[Operator/NifiCluster]** Updated `login_identity_providers.xml` template for 2.0.0-M1.
 - [PR #368](https://github.com/konpyutaika/nifikop/pull/368) - **[Operator]** Upgrade golang to 1.21.6.
+- [PR #369](https://github.com/konpyutaika/nifikop/pull/369) - **[Operator/NifiParameterContext]** Update parameter value to null instead of delete.
 
 ### Fixed Bugs
 

--- a/pkg/clientwrappers/parametercontext/parametercontext.go
+++ b/pkg/clientwrappers/parametercontext/parametercontext.go
@@ -269,8 +269,7 @@ func updateRequestPrepare(
 							(*expected.Parameter.Description == *param.Parameter.Description))) {
 					notFound = false
 					if expected.Parameter.Value == nil && param.Parameter.Value != nil {
-						toRemove = append(toRemove, expected.Parameter.Name)
-						break
+						expected.Parameter.ValueRemoved = true
 					}
 					parameters = append(parameters, expected)
 					break


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Change in the logic of the parameter context updates.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
If the `value` of parameter is deleted, the parameter shouldn't be deleted it should be set to `null`.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [x] Append changelog with changes