### PR TITLE
update pod command curl to strip ellipsis if it exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- [PR #378](https://github.com/konpyutaika/nifikop/pull/378) - **[Operator]** Tweak NiFi pod startup script to more gracefully handle pod IP resolution.
+
 ### Fixed Bugs
 
 ### Deprecated

--- a/pkg/resources/nifi/pod.go
+++ b/pkg/resources/nifi/pod.go
@@ -508,7 +508,7 @@ do
 	echo "Found: $ipResolved, expecting: $POD_IP"
     sleep 5
 
-	ipResolved=$(curl -v -4 -m 1 --connect-timeout 1 %s 2>&1 | grep -o 'Trying [0-9.]*' | awk '{gsub(/\.\.\./, "") print $2}' | head -n 1)
+	ipResolved=$(curl -v -4 -m 1 --connect-timeout 1 %s 2>&1 | grep -o 'Trying [0-9.]*' | awk '{gsub(/\.\.\./, ""); print $2}' | head -n 1)
 	echo "Found : $ipResolved"
     if [[ "$ipResolved" == "$POD_IP" ]]; then
 		echo Ip match for $POD_IP

--- a/pkg/resources/nifi/pod.go
+++ b/pkg/resources/nifi/pod.go
@@ -508,7 +508,7 @@ do
 	echo "Found: $ipResolved, expecting: $POD_IP"
     sleep 5
 
-	ipResolved=$(curl -v -4 -m 1 --connect-timeout 1 %s 2>&1 | grep -o 'Trying [0-9.]*' | awk '{print $2}' | head -n 1)
+	ipResolved=$(curl -v -4 -m 1 --connect-timeout 1 %s 2>&1 | grep -o 'Trying [0-9.]*' | awk '{gsub(/\.\.\./, "") print $2}' | head -n 1)
 	echo "Found : $ipResolved"
     if [[ "$ipResolved" == "$POD_IP" ]]; then
 		echo Ip match for $POD_IP


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

After upgrading to nifikop v1.7.0, the following was observed during pod startup for a headless `NifiCluster`:

```bash
Waiting for host to be reachable
failed to reach nifi-1-node.nifi-headless.nifi.svc.cluster.local:8443
Found: 1.2.3.4..., expecting: 1.2.3.4
```

I am running a custom NiFi image, so i believe this could be due to the curl version in the OS. I found that it was `v7.29.0`.

I ran the following tests to ensure this will handle both of the following cases:
```bash
user $ echo "Trying 1.2.3.4..." | awk '{gsub(/\.\.\./, ""); print $2}'
1.2.3.4
user $ echo "Trying 1.2.3.4" | awk '{gsub(/\.\.\./, ""); print $2}'
1.2.3.4
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
