### PR TITLE
Introduce NifiUserGroup.Spec.Identity to explicitly set group identity in NiFi cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- [PR #381](https://github.com/konpyutaika/nifikop/pull/381) - **[Operator/NifiUserGroup]** Added ability to set `NifiUserGroup.Spec.Identity` when users need to override the default naming convention.
+
 ### Changed
 
 ### Fixed Bugs

--- a/api/v1/nifiusergroup_types.go
+++ b/api/v1/nifiusergroup_types.go
@@ -11,6 +11,10 @@ import (
 
 // NifiUserGroupSpec defines the desired state of NifiUserGroup.
 type NifiUserGroupSpec struct {
+	// identity field is used to define the group identity on NiFi cluster side, when the group's name doesn't
+	// suit with Kubernetes resource name.
+	// +optional
+	Identity string `json:"identity,omitempty"`
 	// clusterRef contains the reference to the NifiCluster with the one the registry client is linked.
 	ClusterRef ClusterReference `json:"clusterRef"`
 	// userRef contains the list of reference to NifiUsers that are part to the group.
@@ -53,6 +57,10 @@ func init() {
 	SchemeBuilder.Register(&NifiUserGroup{}, &NifiUserGroupList{})
 }
 
+// GetIdentity returns this group's identity in the NiFi cluster configuration. If no Spec.Identity is set, it defaults to <namespace>-<name>.
 func (n NifiUserGroup) GetIdentity() string {
-	return fmt.Sprintf("%s-%s", n.Namespace, n.Name)
+	if n.Spec.Identity == "" {
+		return fmt.Sprintf("%s-%s", n.Namespace, n.Name)
+	}
+	return n.Spec.Identity
 }

--- a/config/crd/bases/nifi.konpyutaika.com_nifiusergroups.yaml
+++ b/config/crd/bases/nifi.konpyutaika.com_nifiusergroups.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
   name: nifiusergroups.nifi.konpyutaika.com
 spec:
   group: nifi.konpyutaika.com
@@ -79,6 +78,8 @@ spec:
                 required:
                 - name
                 type: object
+              identity:
+                type: string
               usersRef:
                 items:
                   properties:

--- a/helm/nifi-cluster/templates/nifi-user-group.yaml
+++ b/helm/nifi-cluster/templates/nifi-user-group.yaml
@@ -4,6 +4,9 @@ kind: NifiUserGroup
 metadata:
   name: {{ include "nifi-cluster.fullname" $ }}-{{ .name }}
 spec:
+  {{ if .identity }}
+  identity: {{ .identity }}
+  {{ end }}
   clusterRef:
     name: {{ include "nifi-cluster.fullname" $ }}
     namespace: {{ $.Release.Namespace }}

--- a/helm/nifi-cluster/values.yaml
+++ b/helm/nifi-cluster/values.yaml
@@ -427,6 +427,8 @@ users: []
 # See all properties here: https://konpyutaika.github.io/nifikop/docs/5_references/6_nifi_usergroup
 userGroups: []
   # - name: "basic-user-group"
+  #   # identity is an optional field. It defaults to the CRD '<namespace>-<name>'.
+  #   identity: "My Special group"
   #   # Users listed here should match the identity of users provided via the `users` configuration
   #   users:
   #     - name: CN=first last, OU=Apache NiFi, O=Apache, L=Santa Monica, ST=CA, C=US

--- a/helm/nifi-cluster/values.yaml
+++ b/helm/nifi-cluster/values.yaml
@@ -427,8 +427,8 @@ users: []
 # See all properties here: https://konpyutaika.github.io/nifikop/docs/5_references/6_nifi_usergroup
 userGroups: []
   # - name: "basic-user-group"
-  #   # identity is an optional field. It defaults to the CRD '<namespace>-<name>'.
-  #   identity: "My Special group"
+  #   identity is an optional field. It defaults to the CRD '<namespace>-<name>'.
+  #   identity: "My Special Group"
   #   # Users listed here should match the identity of users provided via the `users` configuration
   #   users:
   #     - name: CN=first last, OU=Apache NiFi, O=Apache, L=Santa Monica, ST=CA, C=US

--- a/helm/nifikop/crds/nifi.konpyutaika.com_nifiusergroups.yaml
+++ b/helm/nifikop/crds/nifi.konpyutaika.com_nifiusergroups.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
   name: nifiusergroups.nifi.konpyutaika.com
 spec:
   group: nifi.konpyutaika.com
@@ -79,6 +78,8 @@ spec:
                 required:
                 - name
                 type: object
+              identity:
+                type: string
               usersRef:
                 items:
                   properties:

--- a/site/docs/5_references/6_nifi_usergroup.md
+++ b/site/docs/5_references/6_nifi_usergroup.md
@@ -12,6 +12,7 @@ kind: NifiUserGroup
 metadata:
   name: group-test
 spec:
+  identity: "My Special Group"
   clusterRef:
     name: nc
     namespace: nifikop
@@ -35,6 +36,7 @@ spec:
 
 |Field|Type|Description|Required|Default|
 |-----|----|-----------|--------|--------|
+|identity|string| Used to define the group's identity on NiFi cluster side, when the group's name doesn't suit Kubernetes resource name requirements. |No| - |
 |clusterRef|[ClusterReference](./2_nifi_user#clusterreference)|  contains the reference to the NifiCluster with the one the user is linked. |Yes| - |
 |usersRef|\[&nbsp;\][UserReference](#userref)| contains the list of reference to NifiUsers that are part to the group. |No| [] |
 |accessPolicies|\[&nbsp;\][AccessPolicy](./2_nifi_user#accesspolicy)| defines the list of access policies that will be granted to the group. |No| [] |


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #380 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This PR adds `NifiUserGroup.Spec.Identity`, which behaves similarly to `NifiUser.Spec.Identity`, to give users control over the actual group Identity created in the NiFi cluster by nifikop.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

See #380 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
