### PR TITLE
Changed nifi.content.viewer.url property default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- [PR #382](https://github.com/konpyutaika/nifikop/pull/382) - **[Operator/NifiCluster]** Changed `nifi.content.viewer.url` property default value.
+
 ### Fixed Bugs
 
 ### Deprecated

--- a/pkg/resources/templates/config/nifi_properties.go
+++ b/pkg/resources/templates/config/nifi_properties.go
@@ -88,7 +88,7 @@ nifi.content.repository.archive.max.retention.period=3 days
 nifi.content.repository.archive.max.usage.percentage=85%
 nifi.content.repository.archive.enabled=true
 nifi.content.repository.always.sync=false
-nifi.content.viewer.url=/nifi-content-viewer/
+nifi.content.viewer.url=../nifi-content-viewer/
 
 # Provenance Repository Properties
 nifi.provenance.repository.implementation=org.apache.nifi.provenance.WriteAheadProvenanceRepository


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
A change of the default value of `nifi.content.viewer.url` from `/nifi-content-viewer/` to `../nifi-content-viewer/`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Because it's the default based on NiFi documentation.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
I think `/nifi-content-viewer/` is the previous default value but has changed at some point.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [x] Append changelog with changes