### PR TITLE
Propage WebProxyHosts update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Added
 
 - [PR #381](https://github.com/konpyutaika/nifikop/pull/381) - **[Operator/NifiUserGroup]** Added ability to set `NifiUserGroup.Spec.Identity` when users need to override the default naming convention.
+- [PR #392](https://github.com/konpyutaika/nifikop/pull/392) - **[Operator/NifiCluster]** Added update of the `DNSNames` of the node's `NifiUsers` if the `webProxyHosts` is updated.
+- [PR #392](https://github.com/konpyutaika/nifikop/pull/392) - **[Operator/NifiUser]** Added update of the `Certificate` if the `NifiUser` is updated.
 
 ### Changed
 

--- a/internal/controller/nifiuser_controller.go
+++ b/internal/controller/nifiuser_controller.go
@@ -189,7 +189,7 @@ func (r *NifiUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			// using the vault backend, then tried to delete and fix it. Should probably
 			// have the PKIManager export a GetUserCertificate specifically for deletions
 			// that will allow the error to fall through if the certificate doesn't exist.
-			_, err := pkiManager.ReconcileUserCertificate(ctx, instance, r.Scheme)
+			_, err := pkiManager.ReconcileUserCertificate(ctx, r.Log, instance, r.Scheme)
 			if err != nil {
 				switch errors.Cause(err).(type) {
 				case errorfactory.ResourceNotReady:

--- a/pkg/k8sutil/resource.go
+++ b/pkg/k8sutil/resource.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	nifikopv1 "github.com/konpyutaika/nifikop/api/v1"
 	"github.com/konpyutaika/nifikop/pkg/errorfactory"
 )
@@ -67,6 +68,18 @@ func Reconcile(log zap.Logger, client runtimeClient.Client, desired runtimeClien
 			group := desired.(*nifikopv1.NifiUserGroup)
 			group.Status = current.(*nifikopv1.NifiUserGroup).Status
 			desired = group
+		case *certv1.ClusterIssuer:
+			issuer := desired.(*certv1.ClusterIssuer)
+			issuer.Status = current.(*certv1.ClusterIssuer).Status
+			desired = issuer
+		case *certv1.Issuer:
+			issuer := desired.(*certv1.Issuer)
+			issuer.Status = current.(*certv1.Issuer).Status
+			desired = issuer
+		case *certv1.Certificate:
+			certificate := desired.(*certv1.Certificate)
+			certificate.Status = current.(*certv1.Certificate).Status
+			desired = certificate
 		}
 
 		if CheckIfObjectUpdated(log, desiredType, current, desired) {

--- a/pkg/k8sutil/resource.go
+++ b/pkg/k8sutil/resource.go
@@ -95,6 +95,18 @@ func Reconcile(log zap.Logger, client runtimeClient.Client, desired runtimeClien
 				svc.ResourceVersion = current.(*corev1.Service).ResourceVersion
 				svc.Spec.ClusterIP = current.(*corev1.Service).Spec.ClusterIP
 				desired = svc
+			case *certv1.ClusterIssuer:
+				issuer := desired.(*certv1.ClusterIssuer)
+				issuer.ResourceVersion = current.(*certv1.ClusterIssuer).ResourceVersion
+				desired = issuer
+			case *certv1.Issuer:
+				issuer := desired.(*certv1.Issuer)
+				issuer.ResourceVersion = current.(*certv1.Issuer).ResourceVersion
+				desired = issuer
+			case *certv1.Certificate:
+				certificate := desired.(*certv1.Certificate)
+				certificate.ResourceVersion = current.(*certv1.Certificate).ResourceVersion
+				desired = certificate
 			}
 
 			if cr != nil {

--- a/pkg/pki/certmanagerpki/certmanager_user_test.go
+++ b/pkg/pki/certmanagerpki/certmanager_user_test.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 
-	"github.com/konpyutaika/nifikop/api/v1"
+	v1 "github.com/konpyutaika/nifikop/api/v1"
 	"github.com/konpyutaika/nifikop/pkg/errorfactory"
 	certutil "github.com/konpyutaika/nifikop/pkg/util/cert"
 )
@@ -49,7 +49,7 @@ func TestReconcileUserCertificate(t *testing.T) {
 	ctx := context.Background()
 
 	manager.client.Create(context.TODO(), newMockUser())
-	if _, err := manager.ReconcileUserCertificate(ctx, newMockUser(), scheme.Scheme); err == nil {
+	if _, err := manager.ReconcileUserCertificate(ctx, *log, newMockUser(), scheme.Scheme); err == nil {
 		t.Error("Expected resource not ready error, got nil")
 	} else if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.ResourceNotReady{}) {
 		t.Error("Expected resource not ready error, got:", reflect.TypeOf(err))
@@ -60,7 +60,7 @@ func TestReconcileUserCertificate(t *testing.T) {
 	if err := manager.client.Create(context.TODO(), newMockUserSecret()); err != nil {
 		t.Error("could not update test secret")
 	}
-	if _, err := manager.ReconcileUserCertificate(ctx, newMockUser(), scheme.Scheme); err != nil {
+	if _, err := manager.ReconcileUserCertificate(ctx, *log, newMockUser(), scheme.Scheme); err != nil {
 		t.Error("Expected no error, got:", err)
 	}
 
@@ -68,7 +68,7 @@ func TestReconcileUserCertificate(t *testing.T) {
 	manager = newMock(newMockCluster())
 	manager.client.Create(context.TODO(), newMockUser())
 	manager.client.Create(context.TODO(), manager.clusterCertificateForUser(newMockUser(), scheme.Scheme))
-	if _, err := manager.ReconcileUserCertificate(ctx, newMockUser(), scheme.Scheme); err == nil {
+	if _, err := manager.ReconcileUserCertificate(ctx, *log, newMockUser(), scheme.Scheme); err == nil {
 		t.Error("Expected  error, got nil")
 	}
 }

--- a/pkg/pki/certmanagerpki/reconcile.go
+++ b/pkg/pki/certmanagerpki/reconcile.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/konpyutaika/nifikop/api/v1"
+	"github.com/konpyutaika/nifikop/pkg/k8sutil"
 )
 
 // reconcile ensures the given kubernetes object.
@@ -44,6 +45,9 @@ func reconcileClusterIssuer(ctx context.Context, log zap.Logger, client client.C
 		}
 		return client.Create(ctx, issuer)
 	}
+	if err = k8sutil.Reconcile(log, client, issuer, cluster, &cluster.Status); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -56,6 +60,9 @@ func reconcileIssuer(ctx context.Context, log zap.Logger, client client.Client, 
 			return err
 		}
 		return client.Create(ctx, issuer)
+	}
+	if err = k8sutil.Reconcile(log, client, issuer, cluster, &cluster.Status); err != nil {
+		return err
 	}
 	return nil
 }
@@ -70,6 +77,9 @@ func reconcileCertificate(ctx context.Context, log zap.Logger, client client.Cli
 		}
 		return client.Create(ctx, cert)
 	}
+	if err = k8sutil.Reconcile(log, client, cert, cluster, &cluster.Status); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -83,6 +93,9 @@ func reconcileSecret(ctx context.Context, log zap.Logger, client client.Client, 
 		}
 		return client.Create(ctx, secret)
 	}
+	if err = k8sutil.Reconcile(log, client, secret, cluster, &cluster.Status); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -95,6 +108,9 @@ func reconcileUser(ctx context.Context, log zap.Logger, client client.Client, us
 			return err
 		}
 		return client.Create(ctx, user)
+	}
+	if err = k8sutil.Reconcile(log, client, user, cluster, &cluster.Status); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/pki/pki_manager.go
+++ b/pkg/pki/pki_manager.go
@@ -58,7 +58,7 @@ func (m *mockPKIManager) FinalizePKI(ctx context.Context, logger zap.Logger) err
 	return nil
 }
 
-func (m *mockPKIManager) ReconcileUserCertificate(ctx context.Context, user *v1.NifiUser, scheme *runtime.Scheme) (*pki.UserCertificate, error) {
+func (m *mockPKIManager) ReconcileUserCertificate(ctx context.Context, logger zap.Logger, user *v1.NifiUser, scheme *runtime.Scheme) (*pki.UserCertificate, error) {
 	return &pki.UserCertificate{}, nil
 }
 

--- a/pkg/pki/pki_manager_test.go
+++ b/pkg/pki/pki_manager_test.go
@@ -51,7 +51,7 @@ func TestGetPKIManager(t *testing.T) {
 		t.Error("Expected nil error got:", err)
 	}
 
-	if _, err = mock.ReconcileUserCertificate(ctx, &v1.NifiUser{}, scheme.Scheme); err != nil {
+	if _, err = mock.ReconcileUserCertificate(ctx, log, &v1.NifiUser{}, scheme.Scheme); err != nil {
 		t.Error("Expected nil error got:", err)
 	}
 

--- a/pkg/resources/nifi/nifi.go
+++ b/pkg/resources/nifi/nifi.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -107,6 +108,8 @@ func (r *Reconciler) Reconcile(log zap.Logger) error {
 	for k := range uniqueHostnamesMap {
 		uniqueHostnames = append(uniqueHostnames, k)
 	}
+	// Preserving order
+	sort.Strings(uniqueHostnames)
 
 	// Setup the PKI if using SSL
 	if r.NifiCluster.Spec.ListenersConfig.SSLSecrets != nil {

--- a/pkg/util/pki/common.go
+++ b/pkg/util/pki/common.go
@@ -46,7 +46,7 @@ type Manager interface {
 	FinalizePKI(ctx context.Context, logger zap.Logger) error
 
 	// ReconcileUserCertificate ensures and returns a user certificate - should be idempotent
-	ReconcileUserCertificate(ctx context.Context, user *v1.NifiUser, scheme *runtime.Scheme) (*UserCertificate, error)
+	ReconcileUserCertificate(ctx context.Context, logger zap.Logger, user *v1.NifiUser, scheme *runtime.Scheme) (*UserCertificate, error)
 
 	// FinalizeUserCertificate removes/revokes a user certificate
 	FinalizeUserCertificate(ctx context.Context, user *v1.NifiUser) error


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/konpyutaika/nifikop/issues/390
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
When the `webProxyHosts` of a `NifiCluster` is updated, the `DNSNames` of the node's `NifiUsers` are updated, and if the `DNSNames` of a `NifiUser` are updated, the associated `Certificate` is updated.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Because if we want to add a new host, if we don't update the certificate, the trustore won't be updated and the host won't be valid in NiFI.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [x] Append changelog with changes