### PR TITLE
Change NifiUser sync logic to reduce api calls on UserGroup endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [PR #387](https://github.com/konpyutaika/nifikop/pull/387) - **[Operator]** Upgrade golang to 1.21.7.
 - [PR #366](https://github.com/konpyutaika/nifikop/pull/366) - **[Operator]** Migrated nifikop to KubeBuilder go/v4 and operator-sdk to v1.33.0.
 - [PR #386](https://github.com/konpyutaika/nifikop/pull/386) - **[Operator]** Upgrade golang to 1.22.0.
+- [PR #397](https://github.com/konpyutaika/nifikop/pull/397) - **[Operator/NifiUser]** Updates `NifiUser` synchronization logic to reduce api calls on `UserGroup` endpoint.
 
 ### Fixed Bugs
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Update of the `NifiUser` sync logic to reduce the number of API call on the `UserGroup` endpoint.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Because if we have a lot of user or node, we will spam NiFi to retrieve the group information.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [x] Append changelog with changes