### PR TITLE
[FIX] correct templating for custom pod probes in `nifi-cluster` chart.

### DIFF
--- a/helm/nifi-cluster/templates/nifi-cluster.yaml
+++ b/helm/nifi-cluster/templates/nifi-cluster.yaml
@@ -27,11 +27,11 @@ spec:
     hostAliases:
     {{- toYaml .Values.cluster.pod.hostAliases | nindent 6}}
   {{- end }}
-  {{- if .Values.cluster.pod.livenessProbe -}}
+  {{- if .Values.cluster.pod.livenessProbe }}
     livenessProbe:
     {{- toYaml .Values.cluster.pod.livenessProbe | nindent 6}}
   {{- end -}}
-  {{- if .Values.cluster.pod.readinessProbe -}}
+  {{- if .Values.cluster.pod.readinessProbe }}
     readinessProbe:
     {{- toYaml .Values.cluster.pod.readinessProbe | nindent 6}}
   {{- end }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | n/a
| License         | Apache 2.0


### What's in this PR?
fixes chart templating to correctly support custom node pod probes.


### Why?
chart rendering currently breaks if custom probes are provided.


### Additional context
n/a


### Checklist
- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [X] Append changelog with changes (changes omitted since no bug has been reported)