### PR TITLE
certmanager-user: k8sutil: corrects IsAlreadyOwnedError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - [PR #415](https://github.com/konpyutaika/nifikop/pull/415) - **[Operator]** Upgrade golang to 1.22.2.
+- [PR #416](https://github.com/konpyutaika/nifikop/pull/416) - **[Operator]** Certmanager-user: k8sutil: corrects IsAlreadyOwnedError.
 
 ### Fixed Bugs
 

--- a/pkg/k8sutil/status.go
+++ b/pkg/k8sutil/status.go
@@ -13,14 +13,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	v1 "github.com/konpyutaika/nifikop/api/v1"
 )
 
 // IsAlreadyOwnedError checks if a controller already own the instance.
 func IsAlreadyOwnedError(err error) bool {
-	return errors.Is(err, &controllerutil.AlreadyOwnedError{})
+	errString := err.Error()
+	// check if "Object */* is already owned by another * controller" is in the error message
+	return strings.Contains(errString, "Object") && strings.Contains(errString, "is already owned by another") && strings.Contains(errString, "controller")
 }
 
 // IsMarkedForDeletion determines if the object is marked for deletion.

--- a/pkg/k8sutil/status_test.go
+++ b/pkg/k8sutil/status_test.go
@@ -1,0 +1,22 @@
+package k8sutil
+
+import (
+	"testing"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func TestErrorIs(t *testing.T) {
+	err := &controllerutil.AlreadyOwnedError{
+		Object: &v1.ObjectMeta{},
+		Owner: v1.OwnerReference{
+			Name: "test",
+		},
+	}
+
+	is := IsAlreadyOwnedError(err)
+	if !is {
+		t.Errorf("Error is not AlreadyOwnedError")
+	}
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
The check, if an error is type of `controllerutil.AlreadyOwnedError` did not work. This PR fixes it.

### Why?
The check, if an error is type of `controllerutil.AlreadyOwnedError` did not work. This PR fixes it.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
