### PR TITLE
Fixed issue where nodes could not be added to existing cluster with a custom authorizer config override configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 ### Changed
 
 - [PR #415](https://github.com/konpyutaika/nifikop/pull/415) - **[Operator]** Upgrade golang to 1.22.2.
-- [PR #416](https://github.com/konpyutaika/nifikop/pull/416) - **[Operator]** Certmanager-user: k8sutil: corrects IsAlreadyOwnedError.
 
 ### Fixed Bugs
+
+- [PR #416](https://github.com/konpyutaika/nifikop/pull/416) - **[Operator]** Certmanager-user: k8sutil: corrects IsAlreadyOwnedError.
+- [PR #418](https://github.com/konpyutaika/nifikop/pull/418) - **[Operator]** Fixed issue where new nodes could not be added to NiFi cluster with a custom authorizer configuration provided.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed Bugs
 
 - [PR #416](https://github.com/konpyutaika/nifikop/pull/416) - **[Operator]** Certmanager-user: k8sutil: corrects IsAlreadyOwnedError.
-- [PR #418](https://github.com/konpyutaika/nifikop/pull/418) - **[Operator]** Fixed issue where new nodes could not be added to NiFi cluster with a custom authorizer configuration provided.
+- [PR #418](https://github.com/konpyutaika/nifikop/pull/418) - **[Operator/NifiCluster]** Fixed issue where new nodes could not be added to NiFi cluster with a custom authorizer configuration provided.
 
 ### Deprecated
 

--- a/pkg/resources/nifi/secretconfig.go
+++ b/pkg/resources/nifi/secretconfig.go
@@ -451,43 +451,44 @@ func (r *Reconciler) getAuthorizersConfigString(nConfig *v1.NodeConfig, id int32
 	nodeList := make(map[string]string)
 
 	authorizersTemplate := config.EmptyAuthorizersTemplate
+	// use a different template for init nodes than nodes joining the cluster.
 	if r.NifiCluster.Status.NodesState[fmt.Sprint(id)].InitClusterNode {
 		authorizersTemplate = config.AuthorizersTemplate
+	}
 
-		// Check for secret/configmap overrides. If there aren't any, then use the default template.
-		if r.NifiCluster.Spec.ReadOnlyConfig.AuthorizerConfig.ReplaceTemplateConfigMap != nil {
-			conf, err := r.getConfigMap(context.TODO(), *r.NifiCluster.Spec.ReadOnlyConfig.AuthorizerConfig.ReplaceTemplateConfigMap)
-			if err != nil {
-				log.Error("error occurred during getting authorizer readonly configmap",
-					zap.String("clusterName", r.NifiCluster.Name),
-					zap.String("configMapName", r.NifiCluster.Spec.ReadOnlyConfig.AuthorizerConfig.ReplaceTemplateConfigMap.Name),
-					zap.String("configMapNamespace", r.NifiCluster.Spec.ReadOnlyConfig.AuthorizerConfig.ReplaceTemplateConfigMap.Namespace),
-					zap.Int32("nodeId", id),
-					zap.Error(err))
-			} else {
-				authorizersTemplate = conf
-			}
+	// Check for secret/configmap overrides. If there aren't any, then use the default template.
+	if r.NifiCluster.Spec.ReadOnlyConfig.AuthorizerConfig.ReplaceTemplateConfigMap != nil {
+		conf, err := r.getConfigMap(context.TODO(), *r.NifiCluster.Spec.ReadOnlyConfig.AuthorizerConfig.ReplaceTemplateConfigMap)
+		if err != nil {
+			log.Error("error occurred during getting authorizer readonly configmap",
+				zap.String("clusterName", r.NifiCluster.Name),
+				zap.String("configMapName", r.NifiCluster.Spec.ReadOnlyConfig.AuthorizerConfig.ReplaceTemplateConfigMap.Name),
+				zap.String("configMapNamespace", r.NifiCluster.Spec.ReadOnlyConfig.AuthorizerConfig.ReplaceTemplateConfigMap.Namespace),
+				zap.Int32("nodeId", id),
+				zap.Error(err))
+		} else {
+			authorizersTemplate = conf
 		}
+	}
 
-		// The secret takes precedence over the ConfigMap, if it exists.
-		if r.NifiCluster.Spec.ReadOnlyConfig.AuthorizerConfig.ReplaceTemplateSecretConfig != nil {
-			conf, err := r.getSecrectConfig(context.TODO(), *r.NifiCluster.Spec.ReadOnlyConfig.AuthorizerConfig.ReplaceTemplateSecretConfig)
-			if err != nil {
-				log.Error("error occurred during getting authorizer readonly secret config",
-					zap.String("clusterName", r.NifiCluster.Name),
-					zap.String("secretName", r.NifiCluster.Spec.ReadOnlyConfig.AuthorizerConfig.ReplaceTemplateSecretConfig.Name),
-					zap.String("secretNamespace", r.NifiCluster.Spec.ReadOnlyConfig.AuthorizerConfig.ReplaceTemplateSecretConfig.Namespace),
-					zap.Int32("nodeId", id),
-					zap.Error(err))
-			} else {
-				authorizersTemplate = conf
-			}
+	// The secret takes precedence over the ConfigMap, if it exists.
+	if r.NifiCluster.Spec.ReadOnlyConfig.AuthorizerConfig.ReplaceTemplateSecretConfig != nil {
+		conf, err := r.getSecrectConfig(context.TODO(), *r.NifiCluster.Spec.ReadOnlyConfig.AuthorizerConfig.ReplaceTemplateSecretConfig)
+		if err != nil {
+			log.Error("error occurred during getting authorizer readonly secret config",
+				zap.String("clusterName", r.NifiCluster.Name),
+				zap.String("secretName", r.NifiCluster.Spec.ReadOnlyConfig.AuthorizerConfig.ReplaceTemplateSecretConfig.Name),
+				zap.String("secretNamespace", r.NifiCluster.Spec.ReadOnlyConfig.AuthorizerConfig.ReplaceTemplateSecretConfig.Namespace),
+				zap.Int32("nodeId", id),
+				zap.Error(err))
+		} else {
+			authorizersTemplate = conf
 		}
+	}
 
-		for nId, nodeState := range r.NifiCluster.Status.NodesState {
-			if nodeState.InitClusterNode {
-				nodeList[nId] = utilpki.GetNodeUserName(r.NifiCluster, util.ConvertStringToInt32(nId))
-			}
+	for nId, nodeState := range r.NifiCluster.Status.NodesState {
+		if nodeState.InitClusterNode {
+			nodeList[nId] = utilpki.GetNodeUserName(r.NifiCluster, util.ConvertStringToInt32(nId))
 		}
 	}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #407
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixes issue where new nifi nodes could not be added to an existing cluster with custom authorizers config configured. 

I have tested by deploying a 1-node cluster with a custom authorizer configuration provided. I waited until nifikop brought the cluster up. I then added an additional nifi node and let nifikop add it to the cluster. Verified the node joined the cluster successfully.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Self evident.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
