### PR TITLE
Patch duplicate Prometheus Reporting Task

### DIFF
--- a/pkg/resources/nifi/nifi.go
+++ b/pkg/resources/nifi/nifi.go
@@ -927,6 +927,8 @@ func (r *Reconciler) reconcileNifiUsersAndGroups(log zap.Logger) error {
 func (r *Reconciler) reconcilePrometheusReportingTask(log zap.Logger) error {
 	var err error
 
+	patchNifiCluster := client.MergeFrom(r.NifiCluster.DeepCopy())
+
 	configManager := config.GetClientConfigManager(r.Client, v1.ClusterReference{
 		Namespace: r.NifiCluster.Namespace,
 		Name:      r.NifiCluster.Name,
@@ -951,7 +953,7 @@ func (r *Reconciler) reconcilePrometheusReportingTask(log zap.Logger) error {
 
 		r.NifiCluster.Status.PrometheusReportingTask = *status
 		if !reflect.DeepEqual(r.NifiCluster.Status, r.NifiClusterCurrentStatus) {
-			if err := r.Client.Status().Update(context.TODO(), r.NifiCluster); err != nil {
+			if err := r.Client.Status().Patch(context.TODO(), r.NifiCluster, patchNifiCluster); err != nil {
 				return errors.WrapIfWithDetails(err, "failed to update PrometheusReportingTask status")
 			}
 		}
@@ -965,7 +967,7 @@ func (r *Reconciler) reconcilePrometheusReportingTask(log zap.Logger) error {
 
 	r.NifiCluster.Status.PrometheusReportingTask = *status
 	if !reflect.DeepEqual(r.NifiCluster.Status, r.NifiClusterCurrentStatus) {
-		if err := r.Client.Status().Update(context.TODO(), r.NifiCluster); err != nil {
+		if err := r.Client.Status().Patch(context.TODO(), r.NifiCluster, patchNifiCluster); err != nil {
 			return errors.WrapIfWithDetails(err, "failed to update PrometheusReportingTask status")
 		}
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Change Status Update to Status Patch when the Prometheus Reporting Task is synced.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
When the Reporting Task is first created, the resource may have been updated. The update therefore fails, resulting in an error and the re-creation of the reporting task and a duplicate.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [ ] Append changelog with changes