### PR TITLE
Change dataflow version type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - [PR #422](https://github.com/konpyutaika/nifikop/pull/422) - **[NiGoApi]** Upgrade NiGoApi to v0.1.0.
 - [PR #425](https://github.com/konpyutaika/nifikop/pull/425) - **[Operator]** Upgrade golang to 1.22.3.
 - [PR #428](https://github.com/konpyutaika/nifikop/pull/428) - **[Documentation]** Upgrade node 22.2.0.
+- [PR #431](https://github.com/konpyutaika/nifikop/pull/431) - **[Operator/NifiCluster]** Changed type of the version field from `VersionControlInformationEntity` to be generic.
+- [PR #431](https://github.com/konpyutaika/nifikop/pull/431) - **[NiGoApi]** Upgrade NiGoApi to v0.1.1.
 
 ### Fixed Bugs
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/imdario/mergo v0.3.14
 	github.com/jarcoal/httpmock v1.3.0
-	github.com/konpyutaika/nigoapi v0.1.0
+	github.com/konpyutaika/nigoapi v0.1.1
 	github.com/onsi/ginkgo/v2 v2.14.0
 	github.com/onsi/gomega v1.30.0
 	github.com/pavel-v-chernykh/keystore-go v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHm
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/konpyutaika/nigoapi v0.1.0 h1:7CUNmceYZIkml5DeQUDrJFKqFbVThPESOUHsi4VwwVI=
-github.com/konpyutaika/nigoapi v0.1.0/go.mod h1:KHZQsQSl2phNKOqrSp/X8y4qoep8/tKC/mTh81uEW2Y=
+github.com/konpyutaika/nigoapi v0.1.1 h1:kSbbkgttz4gRmzvDuaGdjUTpu9RAdfGswepHAhxObkE=
+github.com/konpyutaika/nigoapi v0.1.1/go.mod h1:KHZQsQSl2phNKOqrSp/X8y4qoep8/tKC/mTh81uEW2Y=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/pkg/clientwrappers/dataflow/dataflow.go
+++ b/pkg/clientwrappers/dataflow/dataflow.go
@@ -1,6 +1,7 @@
 package dataflow
 
 import (
+	"fmt"
 	"strings"
 
 	nigoapi "github.com/konpyutaika/nigoapi/pkg/nifi"
@@ -261,7 +262,7 @@ func isNameChanged(flow *v1.NifiDataflow, pgFlowEntity *nigoapi.ProcessGroupEnti
 
 // isVersionSync check if the flow version is out of sync.
 func isVersionSync(flow *v1.NifiDataflow, pgFlowEntity *nigoapi.ProcessGroupEntity) bool {
-	return *flow.Spec.FlowVersion == pgFlowEntity.Component.VersionControlInformation.Version
+	return fmt.Sprint(*flow.Spec.FlowVersion) == fmt.Sprint(pgFlowEntity.Component.VersionControlInformation.Version)
 }
 
 func localChanged(pgFlowEntity *nigoapi.ProcessGroupEntity) bool {
@@ -903,7 +904,7 @@ func updateProcessGroupEntity(
 		RegistryId:       registry.Status.Id,
 		BucketId:         flow.Spec.BucketId,
 		FlowId:           flow.Spec.FlowId,
-		Version:          *flow.Spec.FlowVersion,
+		Version:          fmt.Sprint(*flow.Spec.FlowVersion),
 	}
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Update of `NiGoApi` to `v0.1.1` to change the type of the version field in `VersionControlInformationEntity` from `int32` to `interface{}`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Because starting `2.0.0-M3` the field `version` is a `string` but in the previous version it's a `int32`. So to be compatible with newer and older version we need to use a generic type.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [x] Append changelog with changes