### PR TITLE
Fix `NifiCluster` type fallback to `external` instead of the field value

### DIFF
--- a/api/v1/nificluster_types.go
+++ b/api/v1/nificluster_types.go
@@ -911,7 +911,7 @@ func (c *NifiCluster) GetType() ClusterType {
 	if c.Spec.Type == "" {
 		return InternalCluster
 	}
-	return ExternalCluster
+	return c.Spec.Type
 }
 
 func (c *NifiCluster) IsSet() bool {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fix of the `NifiCluster` type.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
When a type was provided to a `NifiCluster`, the value retrieved was always `external` instead of the field value.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [ ] Append changelog with changes