### PR TITLE
Stop errorfactory from creating errors with nil causes

### DIFF
--- a/pkg/errorfactory/errorfactory.go
+++ b/pkg/errorfactory/errorfactory.go
@@ -97,7 +97,12 @@ type NifiConnectionDeleting struct{ error }
 
 // New creates a new error factory error.
 func New(t interface{}, err error, msg string, wrapArgs ...interface{}) error {
-	wrapped := errors.WrapIfWithDetails(err, msg, wrapArgs...)
+	var wrapped error
+	if err == nil {
+		wrapped = errors.NewWithDetails(msg, wrapArgs...)
+	} else {
+		wrapped = errors.WrapIfWithDetails(err, msg, wrapArgs...)
+	}
 	switch t.(type) {
 	case ResourceNotReady:
 		return ResourceNotReady{wrapped}

--- a/pkg/errorfactory/errorfactory_test.go
+++ b/pkg/errorfactory/errorfactory_test.go
@@ -37,3 +37,17 @@ func TestNew(t *testing.T) {
 		}
 	}
 }
+
+func TestNil(t *testing.T) {
+	for _, errType := range errorTypes {
+		err := New(errType, nil, "no-wrapped-error")
+		expected := "no-wrapped-error"
+		got := err.Error()
+		if got != expected {
+			t.Error("Expected:", expected, "got:", got)
+		}
+		if !emperrors.As(err, &errType) {
+			t.Error("Expected:", reflect.TypeOf(errType), "got:", reflect.TypeOf(err))
+		}
+	}
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Currently when the errorfactory is invoked with a `nil` error the errorfactory will produce an error that has `nil` error field. This PR will create a new underlying error when presented with a `nil` error.

### Why?
Some consumers of the error assume that the error has been populated and when they access the field it triggers a panic. In particular logging code like this in `nificluster_controller.go` fails:

```go
r.Log.Info("Nodes unreachable, may still be starting up", zap.String("reason", err.Error()))
```

Some error producers need to report errors even the underlying failure doesn't produce an error itself. For example in `client.go`:
```go
clusterEntity, err := n.DescribeCluster()
if err != nil || clusterEntity == nil || clusterEntity.Cluster == nil {
	err = errorfactory.New(errorfactory.NodesUnreachable{}, err, fmt.Sprintf("could not connect to nifi nodes: %s", n.opts.NifiURI))
	return err
}
```

### Additional Context
This failure made it more difficult to diagnose some underlying connectivity and configuration issues that I encountered when I moved on from an insecure cluster to an SSL-secured one.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [ ] Append changelog with changes