### PR TITLE
Fixed a bug in the nifi-cluster helm chart where the cluster.logbackConfig.replaceConfigMap couldn't be set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed Bugs
 
+- [PR #452](https://github.com/konpyutaika/nifikop/pull/452) - **[Helm Chart]** Fixed a bug in the nifi-cluster helm chart where the cluster.logbackConfig.replaceConfigMap couldn't be set
+
 ### Deprecated
 
 ### Removed

--- a/helm/nifi-cluster/templates/nifi-cluster.yaml
+++ b/helm/nifi-cluster/templates/nifi-cluster.yaml
@@ -93,18 +93,17 @@ spec:
         data: {{ .Values.cluster.logbackConfig.replaceSecretConfig.data }}
         name: {{ .Values.cluster.logbackConfig.replaceSecretConfig.name }}
         namespace: {{ .Values.cluster.logbackConfig.replaceSecretConfig.namespace }}
+    {{- else if .Values.cluster.logbackConfig.replaceConfigMap }}
+      replaceConfigMap:
+        data: {{ .Values.cluster.logbackConfig.replaceConfigMap.data }}
+        name: {{ .Values.cluster.logbackConfig.replaceConfigMap.name }}
+        namespace: {{ .Values.cluster.logbackConfig.replaceConfigMap.namespace }}
     {{- else }}
       # the default
       replaceSecretConfig:
         data: logback.xml
         name: {{ include "nifi-cluster.fullname" . }}
         namespace: {{ .Release.Namespace }}
-    {{- end }}
-    {{- if .Values.cluster.logbackConfig.replaceConfigMap }}
-      replaceConfigMap:
-        data: {{ .Values.cluster.logbackConfig.replaceConfigMap.data }}
-        name: {{ .Values.cluster.logbackConfig.replaceConfigMap.name }}
-        namespace: {{ .Values.cluster.logbackConfig.replaceConfigMap.namespace }}
     {{- end }}
     nifiProperties:
       overrideSecretConfig:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

The current `cluster.logbackConfig` logic in the nifi-cluster helm chart doesn't allow a user to override the logback.xml with a configMap.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Currently if you set `cluster.logbackConfig.replaceConfigMap` and omit `cluster.logbackConfig.replaceSecretConfig`, the default secret value is added to the NiFiCluster, as well as the configmap value - setting both.

This change allows a user to set either replaceSecretConfig or replaceConfigMap and if unset, falls back to the default.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
