### PR TITLE
Added extra fields in helm/nifi-cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- [PR #454](https://github.com/konpyutaika/nifikop/pull/454) - **[Helm Chart]** Added options in nifi-cluster helm chart to support setting `clientType`, `propagateLabels`, `sidecarConfigs`, `topologySpreadConstraints` and `nifiControllerTemplate` on NiFiCluster CRD.
+
 ### Changed
 
 - [PR #449](https://github.com/konpyutaika/nifikop/pull/449) - **[Operator]** Upgrade golang to 1.23.0.

--- a/helm/nifi-cluster/README.md
+++ b/helm/nifi-cluster/README.md
@@ -22,6 +22,7 @@ A Helm chart for deploying NiFi clusters in Kubernetes
 |-----|------|---------|-------------|
 | cluster.additionalSharedEnvs | list | `[]` | list of additional environment variables to attach to all init containers and the nifi container https://konpyutaika.github.io/nifikop/docs/5_references/1_nifi_cluster/2_read_only_config#readonlyconfig |
 | cluster.bootstrapProperties | object | `{"nifiJvmMemory":"512m","overrideConfigs":"java.arg.4=-Djava.net.preferIPv4Stack=true\njava.arg.log4shell=-Dlog4j2.formatMsgNoLookups=true\n"}` | You can override individual properties in conf/bootstrap.conf https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#bootstrap_properties |
+| cluster.clientType | string | tls | defines if the operator will use basic or tls authentication to query the NiFi cluster |
 | cluster.controllerUserIdentity | string | `nil` | ControllerUserIdentity specifies what to call the static admin user's identity. **Warning: once defined don't change this value either the operator will no longer be able to manage the cluster** |
 | cluster.disruptionBudget | object | `{}` | see https://konpyutaika.github.io/nifikop/docs/5_references/1_nifi_cluster#disruptionbudget |
 | cluster.externalServices | list | `[{"metadata":{"annotations":{},"labels":{}},"name":"nifi-cluster-ip","spec":{"portConfigs":[{"internalListenerName":"http","port":8080}],"type":"ClusterIP"}}]` | Additional k8s services to create and target internal listener ports. Ingress will use these to route traffic to the cluster |
@@ -42,6 +43,7 @@ A Helm chart for deploying NiFi clusters in Kubernetes
 | cluster.managedReaderUsers | list | `[]` | see https://konpyutaika.github.io/nifikop/docs/5_references/1_nifi_cluster#managedusers |
 | cluster.maximumTimerDrivenThreadCount | int | `10` | MaximumTimerDrivenThreadCount defines the maximum number of threads for timer driven processors available to the system. |
 | cluster.nameOverride | string | `"nifi-cluster"` | the full name of the cluster. This is used to set a portion of the name of various nifikop resources |
+| cluster.nifiControllerTemplate | string | `nil` | NifiControllerTemplate specifies the template to be used when naming the node controller (e.g. %s-mysuffix). **Warning: once defined don't change this value either the operator will no longer be able to manage the cluster** |
 | cluster.nifiProperties | object | `{"needClientAuth":false,"overrideConfigs":"nifi.web.proxy.context.path=/nifi-cluster\n","webProxyHosts":[],"webProxyNodePorts":{"enabled":false,"hosts":[]}}` | You can override the individual properties via the overrideConfigs attribute. These will be provided to all pods via secrets. https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#system_properties |
 | cluster.nifiProperties.needClientAuth | bool | `false` | Nifi security client auth |
 | cluster.nifiProperties.webProxyHosts | list | `[]` | List of allowed HTTP Host header values to consider when NiFi is running securely and will be receiving requests to a different host[:port] than it is bound to. Operator will generate comma separated string from list https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#web-properties |
@@ -60,7 +62,9 @@ A Helm chart for deploying NiFi clusters in Kubernetes
 | cluster.service.annotations | object | `{}` | Annotations to apply to each nifi service |
 | cluster.service.headlessEnabled | bool | `true` | Whether or not to create a headless service |
 | cluster.service.labels | object | `{}` | Labels to apply to each nifi service |
+| cluster.sidecarConfigs | list | `[]` | Defines additional sidecar configurations that will run alongside the NiFi pods: https://godoc.org/k8s.io/api/core/v1#Container |
 | cluster.singleUserConfiguration | object | `{"authorizerEnabled":false,"enabled":false,"secretKeys":{"password":"password","username":"username"},"secretRef":{"name":"single-user-credentials","namespace":"nifi"}}` | see https://konpyutaika.github.io/nifikop/docs/5_references/1_nifi_cluster#singleuserconfiguration |
+| cluster.topologySpreadConstraints | list | `[]` | Defines any TopologySpreadConstraint objects to be applied to all nodes. See https://pkg.go.dev/k8s.io/api/core/v1#TopologySpreadConstraint |
 | cluster.type | string | internal | type of the cluster: internal or external. Operator will put internal by default |
 | cluster.zkAddress | string | `"nifi-cluster-zookeeper:2181"` | the hostname and port of the zookeeper service |
 | cluster.zkPath | string | `"/cluster"` | the path in zookeeper to store this cluster's state |

--- a/helm/nifi-cluster/templates/nifi-cluster.yaml
+++ b/helm/nifi-cluster/templates/nifi-cluster.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "nifi-cluster.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.cluster.clientType }}
+  clientType: {{ .Values.cluster.clientType }}
+  {{- end }}
   {{- if .Values.cluster.type }}
   type: {{ .Values.cluster.type }}
   {{- end }}
@@ -61,8 +64,15 @@ spec:
   initContainers:
   {{- toYaml .Values.cluster.initContainers | nindent 4 }}
 {{- end }}
+{{- if .Values.cluster.sidecarConfigs }}
+  sidecarConfigs:
+  {{- toYaml .Values.cluster.sidecarConfigs | nindent 4 }}
+{{- end }}
 {{- if .Values.cluster.nodeUserIdentityTemplate }}
   nodeUserIdentityTemplate: {{ .Values.cluster.nodeUserIdentityTemplate }}
+{{- end }}
+{{- if .Values.cluster.nifiControllerTemplate }}
+  nifiControllerTemplate: {{ .Values.cluster.nifiControllerTemplate }}
 {{- end }}
 {{- if .Values.cluster.controllerUserIdentity }}
   controllerUserIdentity: {{ .Values.cluster.controllerUserIdentity }}
@@ -77,6 +87,10 @@ spec:
 {{- end }}
   disruptionBudget:
   {{- toYaml .Values.cluster.disruptionBudget | nindent 4 }}
+{{- if .Values.cluster.topologySpreadConstraints }}
+  topologySpreadConstraints:
+  {{- toYaml .Values.cluster.topologySpreadConstraints | nindent 4 }}
+{{- end }}
   ldapConfiguration:
   {{- toYaml .Values.cluster.ldapConfiguration | nindent 4 }}
   readOnlyConfig:
@@ -142,7 +156,7 @@ spec:
   {{- toYaml .Values.cluster.nodeConfigGroups | nindent 4 }}
   nodes:
   {{- toYaml .Values.cluster.nodes | nindent 4 }}
-  propagateLabels: true
+  propagateLabels: {{ .Values.cluster.propagateLabels }}
   nifiClusterTaskSpec:
     retryDurationMinutes: {{ .Values.cluster.retryDurationMinutes }}
   listenersConfig:

--- a/helm/nifi-cluster/values.yaml
+++ b/helm/nifi-cluster/values.yaml
@@ -3,6 +3,9 @@
 # https://konpyutaika.github.io/nifikop/docs/5_references/1_nifi_cluster/1_nifi_cluster
 
 cluster:
+  # -- defines if the operator will use basic or tls authentication to query the NiFi cluster. Operator will default to tls if left unset
+  # @default -- tls
+  clientType:
   # -- type of the cluster: internal or external. Operator will put internal by default
   # @default -- internal
   type:
@@ -20,6 +23,10 @@ cluster:
   # see https://konpyutaika.github.io/nifikop/docs/5_references/1_nifi_cluster#nificlusterspec
   # @default -- "node-%d-<cluster-name>"
   nodeUserIdentityTemplate:
+
+  # -- NifiControllerTemplate specifies the template to be used when naming the node controller (e.g. %s-mysuffix). **Warning: once defined dont' change
+  # this value either the operator will no longer be able to manage the cluster**
+  nifiControllerTemplate:
 
   # -- ControllerUserIdentity specifies what to call the static admin user's identity. **Warning: once defined don't change
   # this value either the operator will no longer be able to manage the cluster**
@@ -67,6 +74,14 @@ cluster:
   # -- list of init containers to run prior to the deployment
   initContainers: []
   
+  # -- list of additional sidecar containers to run alongside the nifi pods. See: https://pkg.go.dev/k8s.io/api/core/v1#Container
+  sidecarConfigs: []
+    # - name: my-sidecar
+    #   image: busybox:1.36
+    #   args:
+    #     - echo
+    #     - helloworld
+
   # --  MaximumTimerDrivenThreadCount defines the maximum number of threads for timer driven processors available to the system.
   maximumTimerDrivenThreadCount: 10
 
@@ -84,6 +99,9 @@ cluster:
 
   # -- see https://konpyutaika.github.io/nifikop/docs/5_references/1_nifi_cluster#disruptionbudget
   disruptionBudget: {}
+
+  # -- specifies any TopologySpreadConstraint objects to be applied to all nodes. See https://pkg.go.dev/k8s.io/api/core/v1#TopologySpreadConstraint
+  topologySpreadConstraints: []
 
   # -- see https://konpyutaika.github.io/nifikop/docs/5_references/1_nifi_cluster#ldapconfiguration
   ldapConfiguration: {}


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Added options in the nifi-cluster helm chart to support setting `clientType`, `propagateLabels`, `sidecarConfigs`, `topologySpreadConstraints` and `nifiControllerTemplate` on NiFiCluster CRD objects.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
