### PR TITLE
Fixed registry update check to use url property

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ orbs:
     executors:
       operator-build:
         docker:
-          - image: ghcr.io/konpyutaika/docker-images/nifikop-build:1.23.2
+          - image: ghcr.io/konpyutaika/docker-images/nifikop-build:1.23.3
     # Define jobs list
     jobs:
       # Build job, which build operator docker image (with operator-sdk build)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - [PR #474](https://github.com/konpyutaika/nifikop/pull/474) - **[NiGoApi]** Upgrade NiGoApi to v0.1.3.
+- [PR #478](https://github.com/konpyutaika/nifikop/pull/478) - **[Operator]** Upgrade golang to 1.23.3.
 
 ### Fixed Bugs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - [PR #476](https://github.com/konpyutaika/nifikop/pull/475) - **[Helm Chart]** Added option in nifi-parameter-context helm chart to support setting `inheritedParameterContexts`.
+- [PR #477](https://github.com/konpyutaika/nifikop/pull/477) - **[Documentation]** Added compatibility matrix for NiFi Registry.
 
 ### Changed
 
@@ -10,6 +11,8 @@
 - [PR #478](https://github.com/konpyutaika/nifikop/pull/478) - **[Operator]** Upgrade golang to 1.23.3.
 
 ### Fixed Bugs
+
+- [PR #477](https://github.com/konpyutaika/nifikop/pull/477) - **[Operator/NifiRegistryClient]** Fixed registry update check to use url property.
 
 ### Deprecated
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23.2 AS builder
+FROM golang:1.23.3 AS builder
 
 WORKDIR /workspace
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DOCKER_REGISTRY_BASE 	?= ghcr.io/konpyutaika/docker-images
 IMAGE_TAG				?= $(shell git describe --tags --abbrev=0 --match '[0-9].*[0-9].*[0-9]' 2>/dev/null)
 IMAGE_NAME 				?= $(SERVICE_NAME)
 BUILD_IMAGE				?= ghcr.io/konpyutaika/docker-images/nifikop-build
-GOLANG_VERSION          ?= 1.23.2
+GOLANG_VERSION          ?= 1.23.3
 IMAGE_TAG_BASE ?= <registry>/<operator name>
 OS = $(shell go env GOOS)
 ARCH = $(shell go env GOARCH)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/konpyutaika/nifikop
 
-go 1.23.2
+go 1.23.3
 
 require (
 	emperror.dev/errors v0.8.1

--- a/pkg/clientwrappers/registryclient/registryclient.go
+++ b/pkg/clientwrappers/registryclient/registryclient.go
@@ -105,7 +105,7 @@ func RemoveRegistryClient(registryClient *v1.NifiRegistryClient,
 func registryClientIsSync(registryClient *v1.NifiRegistryClient, entity *nigoapi.FlowRegistryClientEntity) bool {
 	return registryClient.Name == entity.Component.Name &&
 		registryClient.Spec.Description == entity.Component.Description &&
-		registryClient.Spec.Uri == entity.Uri
+		registryClient.Spec.Uri == entity.Component.Properties["url"]
 }
 
 func updateRegistryClientEntity(registryClient *v1.NifiRegistryClient, entity *nigoapi.FlowRegistryClientEntity) {

--- a/site/docs/4_compatibility_versions.md
+++ b/site/docs/4_compatibility_versions.md
@@ -61,7 +61,7 @@ Nifikop supports the following features for externally deployed clusters:
 
 Nifikop supports the following features for configuring users and user policies:
 
-| NiFi Version  | User Deployment | User Policies |
+| NiFi Version  | User deployment | User policies |
 |---------------|-----------------|---------------|
 | NiFi 1.16     | Yes             | Yes           |
 | NiFi 1.17     | Yes             | Yes           |
@@ -86,7 +86,7 @@ Nifikop supports the following features for configuring users and user policies:
 
 Nifikop supports the following features for configuring user groups:
 
-| NiFi Version  | Group Deployment | Group Policies |
+| NiFi Version  | Group deployment | Group policies |
 |---------------|------------------|----------------|
 | NiFi 1.16     | Yes              | Yes            |
 | NiFi 1.17     | Yes              | Yes            |
@@ -131,6 +131,32 @@ Nifikop supports the following features for managing dataflows:
 | NiFi 2.0.0-M3 | Yes                 | Yes               | Yes                      | Yes                        |
 | NiFi 2.0.0-M4 | Yes                 | Yes               | Yes                      | Yes                        |
 | NiFi 2.0.0    | Yes                 | Yes               | Yes                      | Yes                        |
+
+### NiFi registry
+
+Nifikop supports the following features for managing registries:
+
+| NiFi Version  | Registry deployment |
+|---------------|---------------------|
+| NiFi 1.16     | No                  |
+| NiFi 1.17     | No                  |
+| NiFi 1.18     | Yes                 |
+| NiFi 1.19     | Yes                 |
+| NiFi 1.20     | Yes                 |
+| NiFi 1.21     | Yes                 |
+| NiFi 1.22     | Yes                 |
+| NiFi 1.23     | Yes                 |
+| NiFi 1.24     | Yes                 |
+| NiFi 1.25     | Yes                 |
+| NiFi 1.26     | Yes                 |
+| NiFi 1.27     | Yes                 |
+| NiFi 1.28     | Yes                 |
+| NiFi 2.0.0-M1 | Yes                 |
+| NiFi 2.0.0-M2 | Yes                 |
+| NiFi 2.0.0-M3 | Yes                 |
+| NiFi 2.0.0-M4 | Yes                 |
+| NiFi 2.0.0    | Yes                 |
+
 
 ### NiFi parameter context
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | yes
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
- Fixed NifiRegistry update check to use URL property instead of Uri because the Uri now is the URL in the API of the component.
-  Added compatibility matrix for Registry.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The operator was spamming NiFi and updating the registry controller again and again.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [ ] Append changelog with changes