### PR TITLE
Fix /parameter_contexts access policy creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed Bugs
 
+- [PR #481](https://github.com/konpyutaika/nifikop/pull/481) - **[Operator/NifiUserGroup]** Fixed `/parameter_contexts` access policy creation.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/clientwrappers/accesspolicies/policies.go
+++ b/pkg/clientwrappers/accesspolicies/policies.go
@@ -26,7 +26,7 @@ func ExistAccessPolicies(accessPolicy *v1.AccessPolicy, config *clientconfig.Nif
 		return false, err
 	}
 
-	return entity != nil, nil
+	return entity != nil && entity.Component.Resource == string(accessPolicy.Resource), nil
 }
 
 func CreateAccessPolicy(accessPolicy *v1.AccessPolicy, config *clientconfig.NifiConfig) (string, error) {
@@ -63,7 +63,7 @@ func UpdateAccessPolicy(
 		return err
 	}
 
-	// Check if the access policy  exist
+	// Check if the access policy exist
 	exist, err := ExistAccessPolicies(accessPolicy, config)
 	if err != nil {
 		return err

--- a/pkg/clientwrappers/usergroup/usergroup.go
+++ b/pkg/clientwrappers/usergroup/usergroup.go
@@ -3,7 +3,7 @@ package usergroup
 import (
 	nigoapi "github.com/konpyutaika/nigoapi/pkg/nifi"
 
-	"github.com/konpyutaika/nifikop/api/v1"
+	v1 "github.com/konpyutaika/nifikop/api/v1"
 	"github.com/konpyutaika/nifikop/pkg/clientwrappers"
 	"github.com/konpyutaika/nifikop/pkg/clientwrappers/accesspolicies"
 	"github.com/konpyutaika/nifikop/pkg/common"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
`/parameter-contexts` policies weren't created because the operator was detecting `/controller` policies that were inherited.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
As the policies weren't created the operator will try again and again to add them indefinitely which leads in spam on NiFi API.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [x] Append changelog with changes