### PR TITLE
add support for securityContext override in nifikop helm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - [PR #515](https://github.com/konpyutaika/nifikop/pull/515) - **[Helm Chart]** Added SecurityContextContraints to enhance compatibility with Openshift Platform 
+- [PR #519](https://github.com/konpyutaika/nifikop/pull/519) - **[Helm Chart]** Added securityContext override to nifikop helm chart for increased compatibility with strict PSA enforcement.
 
 ### Changed
 

--- a/helm/nifikop/templates/deployment.yaml
+++ b/helm/nifikop/templates/deployment.yaml
@@ -105,8 +105,10 @@ spec:
               name: webhook-server
               protocol: TCP
             {{- end }}
+          {{- if .Values.securityContext }}
           securityContext:
-            allowPrivilegeEscalation: false
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           env:
             - name: WATCH_NAMESPACE
               {{- if .Values.namespaces }}

--- a/helm/nifikop/values.yaml
+++ b/helm/nifikop/values.yaml
@@ -30,7 +30,18 @@ resources:
     memory: 512Mi
 
 ## RunAsUser for OpenShift compatibility
-runAsUser: 1000
+podSecurityContext:
+  runAsUser: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  # runAsUser: 1000
+  # runAsNonRoot: true
+  # seccompProfile:
+  #   type: RuntimeDefault
+  # capabilities:
+  #   drop:
+  #     - ALL
 
 ## pod spec host aliases for the operator
 ## Ref: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
@@ -63,3 +74,4 @@ certManager:
 
 webhook:
   enabled: true
+


### PR DESCRIPTION
* Modify nifikop deployment.yaml to accept securtiyContext from values.yaml
* Add default values and example to values.yaml

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

In nifikop helm chart, add ability to override security context for containers in nifikop operator pod.

Added old default values to default values.yaml, in order to maintain backwards compatibility

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

For Kubernetes clusters enforcing restricted pod security admission rules, there is a need to configure stricter security context settings for the containers than what was previously possbile when deploying nifikop using the helm chart

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Append changelog with changes
