### PR TITLE
feature: Add IPv6 Support for NifiCluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - [PR #500](https://github.com/konpyutaika/nifikop/pull/500) - **[Operator/NiFiCluster]** Added support for [Zarf](https://zarf.dev/) patched container images.
+- [PR #525](https://github.com/konpyutaika/nifikop/pull/525) - **[Operator/NiFiCluster]** Added support for IPv6 in NifiClutser
 - [PR #544](https://github.com/konpyutaika/nifikop/pull/544) - **[Helm Chart]** Added additionnal envs.
 - [PR #553](https://github.com/konpyutaika/nifikop/pull/553) - **[Helm Chart]** Added Service Account annotations and labels
 

--- a/pkg/resources/nifi/pod.go
+++ b/pkg/resources/nifi/pod.go
@@ -433,11 +433,11 @@ func (r *Reconciler) createNifiNodeContainer(nodeConfig *v1.NodeConfig, id int32
 			Value: zkAddress,
 		},
 		{
-			Name: "POD_IP",
+			Name: "POD_IPS",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
 					APIVersion: "v1",
-					FieldPath:  "status.podIP",
+					FieldPath:  "status.podIPs",
 				},
 			},
 		},
@@ -484,13 +484,13 @@ notMatchedIp=true
 while $notMatchedIp
 do
 	echo "failed to reach %s"
-	echo "Found: $ipResolved, expecting: $POD_IP"
-    sleep 5
+	echo "Found: $ipResolved, expecting: $POD_IPS"
+	sleep 5
 
-	ipResolved=$(curl -v -4 -m 1 --connect-timeout 1 %s 2>&1 | grep -o 'Trying [0-9.]*' | awk '{gsub(/\.\.\./, ""); print $2}' | head -n 1)
+	ipResolved=$(curl -v -m 1 --connect-timeout 1 %s 2>&1 | egrep -o 'Trying [0-9.]*|Trying [0-9a-f:]*' | awk '{gsub(/\.\.\./, ""); print $2}' | awk -F':' 'NF == 1 {print $1} NF > 1 {OFS=":"; NF--; print $0}' | head -n 1)
 	echo "Found: $ipResolved"
-    if [[ "$ipResolved" == "$POD_IP" ]]; then
-		echo Ip match for $POD_IP
+	if [[ "$POD_IPS" == *"$ipResolved"* ]]; then
+		echo Ip match for $POD_IPS
 		notMatchedIp=false
 	fi
 done


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #523
| License         | Apache 2.0


### What's in this PR?
Adding support for IPv6 only K8s clusters (where pods only has IPv6 address).
For that purpose, changed `POD_IP ` to be `POD_IPS` and reflect all the pod's IPs (including IPv6).
In addition, changed nifi-cluster's pods startup script to also look for IPv6 match (in addition to IPv4)
Finally, added some java options to prefer using IPv6 over Ipv4 for nifi-cluster's pods.

### Why?
Before this fix, nifi-cluster pods that had only IPv6 address failed to start because IP match wasn't found


### Additional context
Built an image with changes, tested on IPv6 only cluster and on dual-stack K3s cluster and seems to work.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [ ] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)
- [x] Append changelog with changes
