### PR TITLE
Fix: handle users removal from usergroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed Bugs
 
+- [PR #536](https://github.com/konpyutaika/nifikop/pull/536) - **[Operator/NifiUserGroup]** Fixed users removal from usergroups 
+
 ### Deprecated
 
 ### Removed

--- a/pkg/clientwrappers/usergroup/usergroup.go
+++ b/pkg/clientwrappers/usergroup/usergroup.go
@@ -151,7 +151,7 @@ func userGroupIsSync(
 	userGroup *v1.NifiUserGroup,
 	users []*v1.NifiUser,
 	entity *nigoapi.UserGroupEntity) bool {
-	if userGroup.GetIdentity() != entity.Component.Identity {
+	if userGroup.GetIdentity() != entity.Component.Identity || len(users) != len(entity.Component.Users) {
 		return false
 	}
 
@@ -189,6 +189,7 @@ func updateUserGroupEntity(userGroup *v1.NifiUserGroup, users []*v1.NifiUser, en
 
 	entity.Component.Identity = userGroup.GetIdentity()
 
+	entity.Component.Users = make([]nigoapi.TenantEntity, 0)
 	for _, user := range users {
 		entity.Component.Users = append(entity.Component.Users, nigoapi.TenantEntity{Id: user.Status.Id})
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
Handle correctly the deletion of a user from a usergroup:
  - Detect that the group is not insync when a user is deleted from a usergroup
  - Actually update the group without the deleted user


### Why?
Right now once a user is added to a usergroup its never deleted on NiFi's side, even if its removed from the nifiusergroup resource.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [ ] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)
- [x] Append changelog with changes

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here