### PR TITLE
Add Service Account annotations and labels (konpyutaika#552)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [PR #500](https://github.com/konpyutaika/nifikop/pull/500) - **[Operator/NiFiCluster]** Added support for [Zarf](https://zarf.dev/) patched container images.
 - [PR #544](https://github.com/konpyutaika/nifikop/pull/544) - **[Helm Chart]** Added additionnal envs.
+- [PR #553](https://github.com/konpyutaika/nifikop/pull/553) - **[Helm Chart]** Added Service Account annotations and labels
 
 ### Changed
 

--- a/helm/nifi-cluster/templates/nifi-cluster.yaml
+++ b/helm/nifi-cluster/templates/nifi-cluster.yaml
@@ -175,10 +175,10 @@ spec:
   {{- if empty .Values.cluster.nodeConfigGroups }}
     {{- if eq .Values.cluster.manager "kubernetes" }}
     default-group:
-      serviceAccountName: {{ include "nifi-cluster.fullname" . }}
+      serviceAccountName: {{ tpl (default (include "nifi-cluster.fullname" .) .Values.serviceAccount.name) . }}
     {{- end }}
   {{- else }}
-  {{- toYaml .Values.cluster.nodeConfigGroups | nindent 4 }}
+  {{- tpl (toYaml .Values.cluster.nodeConfigGroups) . | nindent 4 }}
   {{- end }}
   nodes:
   {{- toYaml .Values.cluster.nodes | nindent 4 }}

--- a/helm/nifi-cluster/templates/service-account.yaml
+++ b/helm/nifi-cluster/templates/service-account.yaml
@@ -1,8 +1,13 @@
-{{ if eq .Values.cluster.manager "kubernetes" }}
+{{- if eq .Values.cluster.manager "kubernetes" }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "nifi-cluster.fullname" . }}
----
-{{ end }}
+  name: {{ tpl (default (include "nifi-cluster.fullname" .) .Values.cluster.managerServiceAccount.name) . }}
+  namespace: {{ .Release.Namespace }}
+  annotations: 
+{{ toYaml .Values.cluster.managerServiceAccount.annotations | indent 4 }}
+  labels: 
+{{ toYaml .Values.cluster.managerServiceAccount.labels | indent 4 }}
+{{- end }}
+

--- a/helm/nifi-cluster/values.yaml
+++ b/helm/nifi-cluster/values.yaml
@@ -15,6 +15,14 @@ cluster:
   # -- the type of cluster manager: zookeeper or kubernetes. Operator will put zookeeper by default
   # @default -- zookeeper
   manager:
+  # -- the kubernetes manager serviceAccount details
+  managerServiceAccount:
+    # @default -- include "nifi-cluster.fullname" .
+    name:
+    # -- Annotations to apply to the serviceAccount
+    annotations: {}
+    # -- Labels to apply to the serviceAccount
+    labels: {}
   # -- the hostname and port of the zookeeper service
   zkAddress: "nifi-cluster-zookeeper:2181"
   # -- the path in zookeeper to store this cluster's state


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #552 
| License         | Apache 2.0


### What's in this PR?
Added the ability to specify a custom name for the service account created when using kubernetes as the manager, as well as adding annotations and labels

### Why?
It allows the ability to integrate with AKS when using managed idenetities for the service account to authorise NiFi against Azure services

### Checklist

- [X] Implementation tested
- [X] Append changelog with changes
