### PR TITLE
Process group name inherited from registry flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [PR #500](https://github.com/konpyutaika/nifikop/pull/500) - **[Operator/NiFiCluster]** Added support for [Zarf](https://zarf.dev/) patched container images.
 - [PR #544](https://github.com/konpyutaika/nifikop/pull/544) - **[Helm Chart]** Added additionnal envs.
 - [PR #553](https://github.com/konpyutaika/nifikop/pull/553) - **[Helm Chart]** Added Service Account annotations and labels
+- [PR #555](https://github.com/konpyutaika/nifikop/pull/555) - **[Operator/NiFiDataflow]** Added displayName optional field
 
 ### Changed
 

--- a/api/v1/nifidataflow_types.go
+++ b/api/v1/nifidataflow_types.go
@@ -33,6 +33,8 @@ type NifiDataflowSpec struct {
 	RegistryClientRef *RegistryClientReference `json:"registryClientRef,omitempty"`
 	// describes the way the operator will deal with data when a dataflow will be updated: drop or drain
 	UpdateStrategy ComponentUpdateStrategy `json:"updateStrategy"`
+	// describes than name that will be used on the created Process Group
+	DisplayName string `json:"displayName,omitempty"`
 }
 
 type FlowPosition struct {
@@ -168,6 +170,13 @@ func (d *NifiDataflowSpec) GetParentProcessGroupID(rootProcessGroupId string) st
 		return rootProcessGroupId
 	}
 	return d.ParentProcessGroupID
+}
+
+func (d *NifiDataflow) GetDisplayName() string {
+	if d.Spec.DisplayName == "" {
+		return d.Name
+	}
+	return d.Spec.DisplayName
 }
 
 func (p *FlowPosition) GetX() int64 {

--- a/pkg/clientwrappers/dataflow/dataflow.go
+++ b/pkg/clientwrappers/dataflow/dataflow.go
@@ -257,7 +257,7 @@ func isParentProcessGroupChanged(
 }
 
 func isNameChanged(flow *v1.NifiDataflow, pgFlowEntity *nigoapi.ProcessGroupEntity) bool {
-	return flow.Name != pgFlowEntity.Component.Name
+	return flow.GetDisplayName() != pgFlowEntity.Component.Name
 }
 
 // isVersionSync check if the flow version is out of sync.
@@ -337,7 +337,7 @@ func SyncDataflow(
 
 	if isNameChanged(flow, pGEntity) || isPostionChanged(flow, pGEntity) {
 		pGEntity.Component.ParentGroupId = flow.Spec.GetParentProcessGroupID(config.RootProcessGroupId)
-		pGEntity.Component.Name = flow.Name
+		pGEntity.Component.Name = flow.GetDisplayName()
 
 		var xPos, yPos float64
 		if flow.Spec.FlowPosition == nil || flow.Spec.FlowPosition.X == nil {
@@ -867,7 +867,7 @@ func updateProcessGroupEntity(
 		entity.Component = &nigoapi.ProcessGroupDto{}
 	}
 
-	entity.Component.Name = flow.Name
+	entity.Component.Name = flow.GetDisplayName()
 	entity.Component.ParentGroupId = flow.Spec.GetParentProcessGroupID(config.RootProcessGroupId)
 
 	var xPos, yPos float64

--- a/site/docs/5_references/5_nifi_dataflow.md
+++ b/site/docs/5_references/5_nifi_dataflow.md
@@ -32,6 +32,7 @@ spec:
     name: dataflow-lifecycle
     namespace: nifikop
   updateStrategy: drain
+  displayName: Dataflow Lifecycle
 ```
 
 ## NifiDataflow
@@ -59,6 +60,7 @@ spec:
 |clusterRef|[ClusterReference](./2_nifi_user#clusterreference)| contains the reference to the NifiCluster with the one the user is linked. |Yes| - |
 |parameterContextRef|[ParameterContextReference](./4_nifi_parameter_context#parametercontextreference)| contains the reference to the ParameterContext with the one the dataflow is linked. |No| - |
 |registryClientRef|[RegistryClientReference](./3_nifi_registry_client#registryclientreference)| contains the reference to the NifiRegistry with the one the dataflow is linked. |Yes| - |
+|displayName|string|the display name for the flow. |No| - |
 
 ## NifiDataflowStatus
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #554
| License         | Apache 2.0


### What's in this PR?
Changes that remove isNameChanged for the dataflow as we should take the name in NiFi Registry 

### Why?
Fixes that the name on Nifi UI is ugly as it takes the Kuberenetes resource name 

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Append changelog with changes