### PR TITLE
Add session affinity field in external service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,20 +3,21 @@
 ### Added
 
 - [PR #500](https://github.com/konpyutaika/nifikop/pull/500) - **[Operator/NiFiCluster]** Added support for [Zarf](https://zarf.dev/) patched container images.
-- [PR #525](https://github.com/konpyutaika/nifikop/pull/525) - **[Operator/NiFiCluster]** Added support for IPv6 in NifiClutser
+- [PR #525](https://github.com/konpyutaika/nifikop/pull/525) - **[Operator/NiFiCluster]** Added support for IPv6 in `NifiCluster`.
 - [PR #544](https://github.com/konpyutaika/nifikop/pull/544) - **[Helm Chart]** Added additionnal envs.
-- [PR #553](https://github.com/konpyutaika/nifikop/pull/553) - **[Helm Chart]** Added Service Account annotations and labels
-- [PR #555](https://github.com/konpyutaika/nifikop/pull/555) - **[Operator/NiFiDataflow]** Added displayName optional field
+- [PR #553](https://github.com/konpyutaika/nifikop/pull/553) - **[Helm Chart]** Added `Service Account` annotations and labels.
+- [PR #555](https://github.com/konpyutaika/nifikop/pull/555) - **[Operator/NiFiDataflow]** Added `displayName` optional field.
+- [PR #562](https://github.com/konpyutaika/nifikop/pull/562) - **[Operator/NiFiCluster]** Added `sessionAffinity` field in external service.
 
 ### Changed
 
 - [PR #538](https://github.com/konpyutaika/nifikop/pull/538) - **[Operator]** Upgrade golang to 1.24.2.
 - [PR #530](https://github.com/konpyutaika/nifikop/pull/551) - **[NiGoApi]** Upgrade NiGoApi to v0.1.8.
-- [PR #557](https://github.com/konpyutaika/nifikop/pull/557) - **[Operator]** Upgrade golang to 1.24.2.
+- [PR #557](https://github.com/konpyutaika/nifikop/pull/557) - **[Operator]** Upgrade golang to 1.24.3.
 
 ### Fixed Bugs
 
-- [PR #536](https://github.com/konpyutaika/nifikop/pull/536) - **[Operator/NifiUserGroup]** Fixed users removal from usergroups 
+- [PR #536](https://github.com/konpyutaika/nifikop/pull/536) - **[Operator/NifiUserGroup]** Fixed users removal from user groups.
 
 ### Deprecated
 

--- a/api/v1/nificluster_types.go
+++ b/api/v1/nificluster_types.go
@@ -578,6 +578,14 @@ type ExternalServiceSpec struct {
 	// (possibly modified by topology and other features).
 	// +optional
 	InternalTrafficPolicy *corev1.ServiceInternalTrafficPolicy `json:"internalTrafficPolicy,omitempty" protobuf:"bytes,23,opt,name=internalTrafficPolicy,casttype=ServiceInternalTrafficPolicy"`
+	// Supports "ClientIP" and "None". Used to maintain session affinity.
+	// Enable client IP based session affinity.
+	// Must be ClientIP or None.
+	// Defaults to ClientIP.
+	// More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+	// +kubebuilder:default:=ClientIP
+	// +optional
+	SessionAffinity corev1.ServiceAffinity `json:"sessionAffinity,omitempty" protobuf:"bytes,7,opt,name=sessionAffinity,casttype=ServiceAffinity"`
 }
 
 type PortConfig struct {

--- a/api/v1alpha1/nificluster_conversion.go
+++ b/api/v1alpha1/nificluster_conversion.go
@@ -406,6 +406,7 @@ func convertExternalServiceSpec(src ExternalServiceSpec) v1.ExternalServiceSpec 
 		LoadBalancerIP:           src.LoadBalancerIP,
 		LoadBalancerSourceRanges: src.LoadBalancerSourceRanges,
 		ExternalName:             src.ExternalName,
+		SessionAffinity:          corev1.ServiceAffinityClientIP,
 	}
 }
 

--- a/config/crd/bases/nifi.konpyutaika.com_nificlusters.yaml
+++ b/config/crd/bases/nifi.konpyutaika.com_nificlusters.yaml
@@ -109,6 +109,9 @@ spec:
                             - port
                             type: object
                           type: array
+                        sessionAffinity:
+                          default: ClientIP
+                          type: string
                         type:
                           type: string
                       required:

--- a/config/crd/bases/nifi.konpyutaika.com_nifidataflows.yaml
+++ b/config/crd/bases/nifi.konpyutaika.com_nifidataflows.yaml
@@ -37,6 +37,8 @@ spec:
                 required:
                 - name
                 type: object
+              displayName:
+                type: string
               flowId:
                 type: string
               flowPosition:

--- a/helm/nifikop/crds/nifi.konpyutaika.com_nificlusters.yaml
+++ b/helm/nifikop/crds/nifi.konpyutaika.com_nificlusters.yaml
@@ -109,6 +109,9 @@ spec:
                             - port
                             type: object
                           type: array
+                        sessionAffinity:
+                          default: ClientIP
+                          type: string
                         type:
                           type: string
                       required:

--- a/helm/nifikop/crds/nifi.konpyutaika.com_nifidataflows.yaml
+++ b/helm/nifikop/crds/nifi.konpyutaika.com_nifidataflows.yaml
@@ -37,6 +37,8 @@ spec:
                 required:
                 - name
                 type: object
+              displayName:
+                type: string
               flowId:
                 type: string
               flowPosition:

--- a/pkg/resources/nifi/service.go
+++ b/pkg/resources/nifi/service.go
@@ -61,7 +61,7 @@ func (r *Reconciler) externalServices(log zap.Logger) []runtimeClient.Object {
 				r.NifiCluster),
 			Spec: corev1.ServiceSpec{
 				Type:                     eService.Spec.Type,
-				SessionAffinity:          corev1.ServiceAffinityClientIP,
+				SessionAffinity:          eService.Spec.SessionAffinity,
 				Selector:                 nifiutil.LabelsForNifi(r.NifiCluster.Name),
 				Ports:                    usedPorts,
 				ClusterIP:                eService.Spec.ClusterIP,

--- a/site/docs/2_deploy_nifikop/1_quick_start.md
+++ b/site/docs/2_deploy_nifikop/1_quick_start.md
@@ -63,7 +63,7 @@ values={[
 ```bash
 # Install the CustomResourceDefinitions and cert-manager itself
 kubectl apply -f \
-    https://github.com/jetstack/cert-manager/releases/download/v1.7.2/cert-manager.yaml
+    https://github.com/jetstack/cert-manager/releases/download/v1.17.2/cert-manager.yaml
 ```
 
 </TabItem>
@@ -72,7 +72,7 @@ kubectl apply -f \
 ```bash
 # Install CustomResourceDefinitions first
 kubectl apply --validate=false -f \
-   https://github.com/jetstack/cert-manager/releases/download/v1.7.2/cert-manager.crds.yaml
+   https://github.com/jetstack/cert-manager/releases/download/v1.17.2/cert-manager.crds.yaml
 
 # Add the jetstack helm repo
 helm repo add jetstack https://charts.jetstack.io

--- a/site/docs/5_references/1_nifi_cluster/7_external_service_config.md
+++ b/site/docs/5_references/1_nifi_cluster/7_external_service_config.md
@@ -67,6 +67,7 @@ Field|Type|Description|Required|Default|
 |loadBalancerClass|string| loadBalancerClass is the class of the load balancer implementation this Service belongs to. | No | - |
 |externalTrafficPolicy|string| See the Kubernetes [traffic policies](https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-policies) documentation. | No | Depends on the `Service` type. |
 |internalTrafficPolicy|string| See the Kubernetes [traffic policies](https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-policies) documentation. | No | Depends on the `Service` type. |
+|sessionAffinity|string| See the Kubernetes [session affinity](https://kubernetes.io/docs/reference/networking/virtual-ips/#session-affinity) documentation. | No | `ClientIP` |
 
 ## PortConfig
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/konpyutaika/nifikop/issues/561
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Added the ability to set the `sessionAffinity` for `externalServices`, but the default value stays as `ClientIP` to prevent a breaking change.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Almost all fields for a service is settable but not this one and some users need it to be.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [x] Append changelog with changes