### PR TITLE
Fix the NiFiKOP Helm for when Cert Manager is disabled ()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - [PR #536](https://github.com/konpyutaika/nifikop/pull/536) - **[Operator/NifiUserGroup]** Fixed users removal from user groups.
 - [PR #565](https://github.com/konpyutaika/nifikop/pull/565) - **[Operator/NifiConnection]** Fixed requeue interval divided by 3.
+- [PR #569](https://github.com/konpyutaika/nifikop/pull/569) - **[Helm Chart]** Fixed templates when cert manager is disabled.
 
 ### Deprecated
 

--- a/helm/nifikop/templates/webhook/certificate.yaml
+++ b/helm/nifikop/templates/webhook/certificate.yaml
@@ -1,6 +1,7 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
 # WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
+{{- if and .Values.certManager.enabled .Values.webhook.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -23,3 +24,4 @@ spec:
     kind: Issuer
     name: selfsigned-issuer
   secretName: {{ template "webhook.secret.name" . }} # this secret will not be prefixed, since it's not managed by kustomize
+{{- end }}

--- a/helm/nifikop/templates/webhook/service.yaml
+++ b/helm/nifikop/templates/webhook/service.yaml
@@ -1,4 +1,4 @@
-
+{{- if .Values.webhook.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,3 +17,4 @@ spec:
       targetPort: 9443
   selector:
     app: {{ template "nifikop.name" . }}
+{{- end }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #568 
| License         | Apache 2.0


### What's in this PR?
Adds an if statement on the Webhook templates for the Helm Chart


### Why?
Fix's when Cert Manager is disabled, it will not try to deploy cert manager related resources

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [ ] Append changelog with changes