### PR TITLE
Added tlsConfig support for the Service Monitor and ability to use Ni..

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [PR #562](https://github.com/konpyutaika/nifikop/pull/562) - **[Operator/NiFiCluster]** Added `sessionAffinity` field in external service.
 - [PR #564](https://github.com/konpyutaika/nifikop/pull/564) - **[Operator/NifiResource]** Implementation of `NifiResource` controller.
 - [PR #564](https://github.com/konpyutaika/nifikop/pull/564) - **[Operator/NiFiDataflow]** Added `parentProcessGroupRef` optional field.
+- [PR #570](https://github.com/konpyutaika/nifikop/pull/570) - **[Helm Chart]** Added `tlsConfig` support for the Service Monitor and ability to use NiFi version 2 monitoring paths.
 
 ### Changed
 

--- a/helm/nifi-cluster/templates/service-monitor.yaml
+++ b/helm/nifi-cluster/templates/service-monitor.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.monitoring.enabled }}
+{{- if .Values.monitoring.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -8,10 +8,31 @@ metadata:
 spec:
   endpoints:
   {{- range .Values.cluster.listenersConfig.internalListeners }}
-  {{- if eq .type "prometheus" }}
-  - path: /metrics/
-    {{- /*this is the name of the metrics port specified in the nifi-cluster service configuration*/}}
-    port: {{.name }}
+  {{- if eq .type .Values.monitoring.internalListenersType }}
+  {{- /*this is the name of the metrics port specified in the nifi-cluster service configuration*/}}
+  - path: {{ .Values.monitoring.path }}
+    port: {{ .name }}
+    {{- if .Values.monitoring.tlsConfig }}
+    tlsConfig:
+      {{- with .Values.monitoring.tlsConfig.caFile }}
+      caFile: {{ . }}
+      {{- end }}
+      {{- with .Values.monitoring.tlsConfig.certFile }}
+      certFile: {{ . }}
+      {{- end }}
+      {{- with .Values.monitoring.tlsConfig.keyFile }}
+      keyFile: {{ . }}
+      {{- end }}
+      {{- with .Values.monitoring.tlsConfig.insecureSkipVerify }}
+      insecureSkipVerify: {{ . }}
+      {{- end }}
+      {{- with .Values.monitoring.tlsConfig.serverName }}
+      serverName: {{ . }}
+      {{- end }}
+    {{- end }}
+    {{- with .Values.monitoring.interval }}
+    interval: {{ . }}
+    {{- end }}
   {{- end }}
   {{- end }}
   namespaceSelector:
@@ -20,4 +41,4 @@ spec:
   selector:
     matchLabels:
       nifi_cr: {{ include "nifi-cluster.fullname" . }}
-{{ end }}
+{{- end }}

--- a/helm/nifi-cluster/values.yaml
+++ b/helm/nifi-cluster/values.yaml
@@ -315,6 +315,19 @@ ingress:
 # Enabling monitoring creates a `ServiceMonitor` custom resource and routes logs to the output of your choice
 monitoring:
   enabled: false
+  # For NiFi Version 2 use the https or http listener
+  internalListenersType: "prometheus"
+  # For NiFi Version 2 use the /nifi-api/flow/metrics/prometheus
+  path: "/metrics"
+  # Optional fields to provide the ServiceMonitor see the following documentation for more information
+  # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.Endpoint 
+  #tlsConfig:
+  #  caFile: 
+  #  certFile:
+  #  keyFile:
+  #  insecureSkipVerify:
+  #  serverName:
+  #interval: 
 
 # Logging is enabled by the banzai cloud logging operator. This can be deployed stand-alone or as a part of the Rancher Logging application.
 # Do not enable this unless you've installed rancher-logging or the banzai logging operator directly.


### PR DESCRIPTION
…Fi version 2 monitoring paths. (konpyutaika#570)

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #560 
| License         | Apache 2.0


### What's in this PR?
Adds the ability to change the port and path for the Service monitor in the NiFi cluster helm chart.
Adds the ability to specify scrape interval and tls config for the Service Monitor.

### Why?
Allows the support for NiFi version 2


### Checklist

- [x] Implementation tested
- [x] Append changelog with changes