### PR TITLE
Fix template not resolving for service monitor

### DIFF
--- a/helm/nifi-cluster/templates/service-monitor.yaml
+++ b/helm/nifi-cluster/templates/service-monitor.yaml
@@ -7,37 +7,36 @@ metadata:
     {{- include "nifi-cluster.labels" . | nindent 4 }}
 spec:
   endpoints:
-  {{- range .Values.cluster.listenersConfig.internalListeners }}
-  {{- if eq .type .Values.monitoring.internalListenersType }}
-  {{- /*this is the name of the metrics port specified in the nifi-cluster service configuration*/}}
-  - path: {{ .Values.monitoring.path }}
-    port: {{ .name }}
-    {{- if .Values.monitoring.tlsConfig }}
+  {{- range $internalListener := .Values.cluster.listenersConfig.internalListeners }}
+  {{- if eq $internalListener.type $.Values.monitoring.internalListenersType }}
+  - path: {{ $.Values.monitoring.path }}
+    port: {{ $internalListener.name }}
+    {{- if $.Values.monitoring.tlsConfig }}
     tlsConfig:
-      {{- with .Values.monitoring.tlsConfig.caFile }}
+      {{- with $.Values.monitoring.tlsConfig.caFile }}
       caFile: {{ . }}
       {{- end }}
-      {{- with .Values.monitoring.tlsConfig.certFile }}
+      {{- with $.Values.monitoring.tlsConfig.certFile }}
       certFile: {{ . }}
       {{- end }}
-      {{- with .Values.monitoring.tlsConfig.keyFile }}
+      {{- with $.Values.monitoring.tlsConfig.keyFile }}
       keyFile: {{ . }}
       {{- end }}
-      {{- with .Values.monitoring.tlsConfig.insecureSkipVerify }}
+      {{- with $.Values.monitoring.tlsConfig.insecureSkipVerify }}
       insecureSkipVerify: {{ . }}
       {{- end }}
-      {{- with .Values.monitoring.tlsConfig.serverName }}
+      {{- with $.Values.monitoring.tlsConfig.serverName }}
       serverName: {{ . }}
       {{- end }}
     {{- end }}
-    {{- with .Values.monitoring.interval }}
+    {{- with $.Values.monitoring.interval }}
     interval: {{ . }}
     {{- end }}
   {{- end }}
   {{- end }}
   namespaceSelector:
     matchNames:
-    - {{ .Release.Namespace }}
+      - {{ .Release.Namespace }}
   selector:
     matchLabels:
       nifi_cr: {{ include "nifi-cluster.fullname" . }}


### PR DESCRIPTION
Emergency fix to resolve the correct .Values as $ was missing from within the range function.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
Issue that the PR #560 broke the service monitor due to uncommitted local changes. 


### Why?
It didn't work due to missing $ from the .Values as its required within a range function

### Additional context
This has now been verified on my local deployment to ensure this works. I think we should also add some type of `helm template .` in the make file if possible @juldrixx to ensure we don't accidently miss anything when building the helm charts?


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested
- [ ] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)
- [ ] Append changelog with changes

### To Do
- Add to changelog