### PR TITLE
Fixing when cert manager or webhook disabled on the helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed Bugs
 
 - [PR #573](https://github.com/konpyutaika/nifikop/pull/573) - **[Helm Chart]** Fixed template not resolving for service monitor.
+- [PR #576](https://github.com/konpyutaika/nifikop/pull/576) - **[Helm Chart]** Fixed template not passing in webhook.enabled or certManager.enabled as arguments for the operator.
 
 ### Deprecated
 

--- a/helm/nifikop/templates/deployment.yaml
+++ b/helm/nifikop/templates/deployment.yaml
@@ -87,12 +87,8 @@ spec:
           args:
             - -metrics-bind-address=:{{ .Values.metrics.port }}
             - -leader-elect
-            {{- if .Values.certManager.enabled }}
             - -cert-manager-enabled={{ .Values.certManager.enabled }}
-            {{- end }}
-            {{- if .Values.webhook.enabled }}
             - -webhook-enabled={{ .Values.webhook.enabled }}
-            {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           name: {{ template "nifikop.name" . }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #575
| License         | Apache 2.0


### What's in this PR?
Fixes that the args are passed to the operator when they are false


### Why?
Current operator helm can't disabled cert manager / webhook, but the other templates are not deployed fixing a problem identified earlier

### Additional context
I have verified Operator starts up with all the workers running this time, and that it doesnt exit after 4 mins as identified with the current release


### Checklist
- [x] Implementation tested
- [x] Append changelog with changes
