### PR TITLE
Improve existing PVC detection by not listing "MarkedForDeletion" ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - [PR #573](https://github.com/konpyutaika/nifikop/pull/573) - **[Helm Chart]** Fixed template not resolving for service monitor.
 - [PR #576](https://github.com/konpyutaika/nifikop/pull/576) - **[Helm Chart]** Fixed template not passing in webhook.enabled or certManager.enabled as arguments for the operator.
-- [PR #580](https://github.com/konpyutaika/nifikop/pull/580) - **[Operator]** Fixed deleted PVC detection
+- [PR #580](https://github.com/konpyutaika/nifikop/pull/580) - **[Operator]** Fixed deleted PVC detection.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [PR #573](https://github.com/konpyutaika/nifikop/pull/573) - **[Helm Chart]** Fixed template not resolving for service monitor.
 - [PR #576](https://github.com/konpyutaika/nifikop/pull/576) - **[Helm Chart]** Fixed template not passing in webhook.enabled or certManager.enabled as arguments for the operator.
+- [PR #580](https://github.com/konpyutaika/nifikop/pull/580) - **[Operator]** Fixed deleted PVC detection
 
 ### Deprecated
 

--- a/pkg/resources/nifi/nifi.go
+++ b/pkg/resources/nifi/nifi.go
@@ -76,7 +76,13 @@ func getCreatedPVCForNode(c client.Client, nodeID int32, namespace, crName strin
 	if err != nil {
 		return nil, err
 	}
-	return foundPVCList.Items, nil
+        PVCList := make([]corev1.PersistentVolumeClaim, 0)
+        for _, pvc := range foundPVCList.Items {
+                if !k8sutil.IsMarkedForDeletion(pvc.ObjectMeta) {
+                        PVCList = append(PVCList, pvc)
+                }
+        }
+        return PVCList, nil
 }
 
 // Reconcile implements the reconcile logic for nifi.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR updates the getCreatedPVCForNode function to return only the PVCs that are not "MarkedForDeletion".

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
There was a bug in the way deleted PVC were handled by the reconcile loop.
When PVCs were deleted (manually or by the operator), they were hanging in "Terminating" status as long as the associated pod was not deleted.
When the pod was effectively deleted, the operator then proceeded to recreate it and the missing PVCs.
Depending on the reconcile loop timing, when the pod is recreated, some of the "old" PVCs could still be around (waiting for actual deletion by k8s) resulting in pod spec pointing to the "wrong" PVC reference.
In such a scenario, the pod is stuck in PENDING state because even if the "reconcileNifiPod" function detects the actual change in PVC spec, it wont trigger a pending pod restart (cf : https://github.com/konpyutaika/nifikop/blob/master/pkg/resources/nifi/nifi.go#L856)

NOTE : that PR somehow changes the operator behaviour. Now when a PVC is deleted the associated pod automatically restart (since the PVC "MarkedForDeletion" is now detected as missing). It was not the case before, but I would say that the new behaviour is more appropriate.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [ ] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)
- [x] Append changelog with changes

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here