### PR TITLE
Fix oidc/ldap typo in quickstart docs

### DIFF
--- a/site/docs/3_manage_nifi/1_manage_clusters/1_deploy_cluster/1_quick_start.md
+++ b/site/docs/3_manage_nifi/1_manage_clusters/1_deploy_cluster/1_quick_start.md
@@ -132,8 +132,8 @@ kubectl create -n nifi -f config/samples/simplenificluster.yaml
 :::info
 You can find other examples for NiFi 2 for:
 - HTTP: `config/samples/http_nificluster.yaml`
-- OIDC: `config/samples/ldap_nificluster.yaml`
-- LDAP: `config/samples/oidc_nificluster.yaml`
+- OIDC: `config/samples/oidc_nificluster.yaml`
+- LDAP: `config/samples/ldap_nificluster.yaml`
 :::
 
 ### On OpenShift


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
Switched the order of oidc/ldap sentences.

### Why?
They were wrongly matched.

### Additional context
None.

### Checklist

- [X] User guide and development docs updated (if needed)