### PR TITLE
added samples for accessing nifi with proxy and context paths

### DIFF
--- a/config/samples/nifi-with-proxy-and-context-path-example/Readme.MD
+++ b/config/samples/nifi-with-proxy-and-context-path-example/Readme.MD
@@ -1,0 +1,72 @@
+## Want to access NiFi over a Context Path? You're at the right place
+
+# NiFi on Kubernetes with Ingress and Path Normalization
+
+This repository contains Kubernetes manifests for deploying **Apache NiFi** using **NiFiKop** behind an **NGINX Ingress Controller**, with an intermediate **NGINX proxy layer** for path normalization.
+
+---
+
+## 📂 Repository Contents
+
+- **Cluster.yaml** → NiFiKop `NifiCluster` CR definition  
+- **Deployment.yaml** → Deployment for the intermediate NGINX proxy  
+- **ConfigMap.yaml** → NGINX proxy configuration (`default.conf`)  
+- **Ingress.yaml** → Ingress resource exposing NiFi via NGINX  
+
+---
+
+## 🏗️ Architecture Overview
+
+User Browser -> Ingress Controller (host/path routing) -> Intermediate NGINX Pod (reverse proxy) -> NiFiKop Service (nifikop) -> NiFi Pods (always serve at /)
+
+The intermediate NGINX Pod is crucial for the Path Normalization
+    - rewrites /nifidev → /
+    - maintains all headers: X-ProxyScheme, X-ProxyHost, etc.
+
+---
+
+## 🔑 Key Concepts
+
+### 1. **Ingress**
+- Routes requests for `https://myserver.example.com/nifidev/`  
+- Forwards traffic to the intermediate NGINX proxy pod  
+- Uses TLS termination at the Ingress  
+
+### 2. **Path Normalization Layer (NGINX Proxy Pod)**
+- Ensures NiFi always receives traffic **at the root path (`/`)**  
+- Rewrites `/nifidev/… → /…` before forwarding to NiFi  
+- Injects proxy headers required by NiFi:
+  - `X-ProxyScheme`
+  - `X-ProxyHost`
+  - `X-ProxyPort`
+  - `Host`
+- Terminates TLS (optional, can run HTTPS → HTTPS)  
+
+### 3. **NiFi (via NiFiKop)**
+- Exposed only within the cluster on HTTPS  
+- Configured with `nifi.web.proxy.host=myserver.example.com` and `nifi.web.proxy.context.path=/nifidev/`
+- Expects requests on `/` (root), not on `/nifidev` or subpaths  
+
+---
+
+## ✅ Why Path Normalization?
+
+NiFi is made up of multiple web applications (UI, API, custom UIs, viewers, etc.).  
+If NiFi is only mapped at `/nifi`, features like **UpdateAttribute UI** won’t work because they’re served at `/update-attribute-ui-<version>`. 
+If you want to use a context path and if your Cluster is behind a Reverse Proxy, you can access nifi through your reverse proxy at a context path of your choice. This is useful especially if you are using Internal Ingress on Kubernetes which usually is the case for Private Clusters on Cloud.  
+
+The **path normalization layer** solves this by:
+- Allowing users to access NiFi at `https://myserver.example.com/nifidev/`  
+- Ensuring NiFi still sees requests at `/` internally  
+
+---
+
+## 🔧 How to Deploy
+
+1. Apply the manifests in order:
+
+```bash
+kubectl apply -f Cluster.yaml
+kubectl apply -f ConfigMap.yaml
+kubectl apply -f Deployment.yaml
+kubectl apply -f Ingress.yaml

--- a/config/samples/nifi-with-proxy-and-context-path-example/configmap.yaml
+++ b/config/samples/nifi-with-proxy-and-context-path-example/configmap.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nifi-nginx-conf
+  namespace: nifi
+data:
+  default.conf: |
+    server {
+        listen 443 ssl;
+
+        server_name myserver.example.com;
+
+        ssl_certificate /etc/nginx/certs/tls.crt;
+        ssl_certificate_key /etc/nginx/certs/tls.key;
+
+        # use your context path here
+        location /nifidev/ {
+            proxy_pass https://nifikop:443/;   # rewrites /nifidev/* → /* for NiFi
+            proxy_ssl_server_name on;
+
+            # NiFi proxy headers
+            proxy_set_header X-ProxyScheme $scheme;
+            proxy_set_header X-ProxyHost $host;
+            proxy_set_header X-ProxyPort $server_port;
+            proxy_set_header X-ProxyContextPath /nifidev;
+            proxy_set_header X-ProxiedEntitiesChain CN=nginx-proxy;
+
+            # Preserve Host for NiFi validation
+            proxy_set_header Host nifi-internal.test.com;
+
+            # Forward client IP
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }

--- a/config/samples/nifi-with-proxy-and-context-path-example/deployment.yaml
+++ b/config/samples/nifi-with-proxy-and-context-path-example/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nifi-nginx-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nifi-nginx-proxy
+  template:
+    metadata:
+      labels:
+        app: nifi-nginx-proxy
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 443
+          volumeMounts:
+            - name: tls-certs
+              mountPath: /etc/nginx/certs
+              readOnly: true
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d
+      volumes:
+        - name: tls-certs
+          secret:
+            secretName: mydomain-tls-secret # Generate or use any valid SSL credentials. Then change this to your TLS secret name
+        - name: nginx-conf
+          configMap:
+            name: nifi-nginx-conf
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nifi-nginx-proxy
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      targetPort: 443
+  selector:
+    app: nifi-nginx-proxy 

--- a/config/samples/nifi-with-proxy-and-context-path-example/ingress.yaml
+++ b/config/samples/nifi-with-proxy-and-context-path-example/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nifikop
+  namespace: nifi
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    nginx.ingress.kubernetes.io/ssl-passthrough: 'false'
+    nginx.ingress.kubernetes.io/use-regex: 'true'
+spec:
+  ingressClassName: nginx
+  rules:
+  # use your domain name here
+    - host: mydomain.example.com
+      http:
+        paths: 
+            # use your context path here
+          - path: /nifidev(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: nifi-nginx-proxy
+                port:
+                  number: 443

--- a/config/samples/nifi-with-proxy-and-context-path-example/nginx-proxy.yaml
+++ b/config/samples/nifi-with-proxy-and-context-path-example/nginx-proxy.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nifi-nginx-conf
+  namespace: nifi
+data:
+  default.conf: |
+    server {
+        listen 443 ssl;
+
+        # use your domain name here
+        server_name mydomain.example.com;
+
+        ssl_certificate /etc/nginx/certs/tls.crt;
+        ssl_certificate_key /etc/nginx/certs/tls.key;
+
+        # use your context path here
+        location /nifidev/ {
+            proxy_pass https://nifikop:443/; 
+            proxy_ssl_server_name on;
+
+            # NiFi proxy headers
+            proxy_set_header X-ProxyScheme $scheme;
+            proxy_set_header X-ProxyHost $host;
+            proxy_set_header X-ProxyPort $server_port;
+            # use your context path here
+            proxy_set_header X-ProxyContextPath /nifidev; 
+            proxy_set_header X-ProxiedEntitiesChain CN=nginx-proxy;
+
+            # Preserve Host for NiFi validation
+            proxy_set_header Host adinifiapp.com;
+
+            # Forward client IP
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }

--- a/config/samples/nifi-with-proxy-and-context-path-example/secured-cluster.yaml
+++ b/config/samples/nifi-with-proxy-and-context-path-example/secured-cluster.yaml
@@ -1,0 +1,242 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: single-user-credentials
+  namespace: nifi
+type: Opaque
+stringData:
+  username: nifikop
+  password: nifikopnifikopnifikop
+---
+apiVersion: nifi.konpyutaika.com/v1
+kind: NifiCluster
+metadata:
+  name: nifikop
+  namespace: nifi
+spec:
+  clusterImage: apache/nifi:2.4.0
+  nodeUserIdentityTemplate: node-%d-nifikop
+  singleUserConfiguration:
+    enabled: true
+    authorizerEnabled: true
+    secretRef:
+      name: "single-user-credentials"
+      namespace: "nifikop"
+    secretKeys:
+      username: "username"
+      password: "password"
+  externalServices:
+    - name: nifikop
+      spec:
+        portConfigs:
+          - internalListenerName: https
+            port: 443
+          - internalListenerName: s2s
+            port: 10000
+        type: ClusterIP
+  listenersConfig:
+    internalListeners:
+      - containerPort: 8443
+        name: https
+        type: https
+      - containerPort: 6007
+        name: cluster
+        type: cluster
+      - containerPort: 10000
+        name: s2s
+        type: s2s
+    sslSecrets:
+      create: true
+      tlsSecretName: nifikop-tls
+  nifiClusterTaskSpec:
+    retryDurationMinutes: 10
+  nodeConfigGroups:
+    default_group:
+      fsGroup: 1337
+      isNode: true
+      externalVolumeConfigs:
+        - name: secretsvolume
+          mountPath: "/opt/nifi/secretstore/"
+          secret:
+            secretName: nifi-dataflow-secrets
+      resourcesRequirements:
+        limits:
+          cpu: "1"
+          memory: 2Gi
+        requests:
+          cpu: "1"
+          memory: 2Gi
+      serviceAccountName: nifikop-cluster
+      storageConfigs:
+        - mountPath: /opt/nifi/nifi-current/logs
+          name: logs
+          pvcSpec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+            storageClassName: "default"
+        - mountPath: /opt/nifi/data
+          name: data
+          pvcSpec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+            storageClassName: "default"
+        - mountPath: /opt/nifi/flowfile_repository
+          name: flowfile-repository
+          pvcSpec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+            storageClassName: "default"
+        - mountPath: /opt/nifi/nifi-current/conf
+          name: conf
+          pvcSpec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+            storageClassName: "default"
+        - mountPath: /opt/nifi/content_repository
+          name: content-repository-default
+          pvcSpec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+            storageClassName: "default"
+        - mountPath: /opt/nifi/provenance_repository
+          name: provenance-repository-default
+          pvcSpec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+            storageClassName: "default"
+  nodes:
+    - id: 0
+      labels:
+        nifi_cr: nifikop
+        nifi_node_group: default_group
+      nodeConfigGroup: default_group
+  propagateLabels: false
+  readOnlyConfig:
+    additionalNifiEnvs:
+      - name: tenant_id
+        valueFrom:
+          secretKeyRef:
+            name: nifi-dataflow-secrets
+            key: tenant_id
+    bootstrapProperties:
+      # nifiJvmMemory: 2g
+      overrideConfigs: |
+        # Java 8 Tuning see https://community.hortonworks.com/articles/7882/hdfnifi-best-practices-for-setting-up-a-high-perfo.html for references
+        java.arg.7=-XX:ReservedCodeCacheSize=256m
+        java.arg.8=-XX:+UseCodeCacheFlushing
+    maximumTimerDrivenThreadCount: 40
+    nifiProperties:
+      overrideConfigs: |
+        nifi.nar.library.autoload.directory=../extensions
+        nifi.sensitive.props.key=nifikopnifikopnifikop
+        nifi.variable.registry.properties=/opt/nifi/nifi-current/conf/variable-registry.properties
+        nifi.web.proxy.context.path=/nifidev/
+      webProxyHosts:
+        - mydomain.example.com
+      needClientAuth: false
+  service:
+    headlessEnabled: true
+  sidecarConfigs:
+    - args:
+        - tail
+        - -n+1
+        - -F
+        - /var/log/nifi-app.log
+      image: busybox:1.36
+      name: app-log
+      resources:
+        limits:
+          cpu: 50m
+          memory: 50Mi
+        requests:
+          cpu: 50m
+          memory: 50Mi
+      volumeMounts:
+        - mountPath: /var/log
+          name: logs
+    - args:
+        - tail
+        - -n+1
+        - -F
+        - /var/log/nifi-bootstrap.log
+      image: busybox:1.36
+      name: bootstrap-log
+      resources:
+        limits:
+          cpu: 50m
+          memory: 50Mi
+        requests:
+          cpu: 50m
+          memory: 50Mi
+      volumeMounts:
+        - mountPath: /var/log
+          name: logs
+    - args:
+        - tail
+        - -n+1
+        - -F
+        - /var/log/nifi-user.log
+      image: busybox:1.36
+      name: user-log
+      resources:
+        limits:
+          cpu: 50m
+          memory: 50Mi
+        requests:
+          cpu: 50m
+          memory: 50Mi
+      volumeMounts:
+        - mountPath: /var/log
+          name: logs
+  clusterManager: kubernetes
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nifikop-cluster
+  namespace: nifi
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nifikop-cluster
+  namespace: nifi
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["*"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nifikop-cluster
+  namespace: nifi
+subjects:
+  - kind: ServiceAccount
+    name: nifikop-cluster
+    namespace: nifi
+roleRef:
+  kind: Role
+  name: nifikop-cluster
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
Added a folder of sample kubernetes manifests for proxy and context path based configurations of NiFI with NiFiKops  
with elaborate details for implementation in the Readme.MD 

### Why?
It will demonstrate the correct approach to use NiFiKops with Proxy and Context Paths  


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [ ] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)
- [ ] Append changelog with changes