### PR TITLE
fix: use cluster.managerServiceAccount.name for kubernetes manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed Bugs
 
+- [PR #644](https://github.com/konpyutaika/nifikop/pull/644) - **[Helm Chart]** Fix `serviceAccountName` value path for Kubernetes manager mode by using `cluster.managerServiceAccount.name`.
+
 ### Deprecated
 
 ### Removed

--- a/helm/nifi-cluster/templates/nifi-cluster.yaml
+++ b/helm/nifi-cluster/templates/nifi-cluster.yaml
@@ -174,7 +174,7 @@ spec:
   {{- if empty .Values.cluster.nodeConfigGroups }}
     {{- if eq .Values.cluster.manager "kubernetes" }}
     default-group:
-      serviceAccountName: {{ tpl (default (include "nifi-cluster.fullname" .) .Values.serviceAccount.name) . }}
+      serviceAccountName: {{ tpl (default (include "nifi-cluster.fullname" .) .Values.cluster.managerServiceAccount.name) . }}
     {{- end }}
   {{- else }}
   {{- tpl (toYaml .Values.cluster.nodeConfigGroups) . | nindent 4 }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    |no
| API breaks?     |no
| Deprecations?   | no
| Related tickets | fixes #642
| License         | Apache 2.0


### What's in this PR?

This PR fixes a Helm values path mismatch in `nifi-cluster.yaml` for Kubernetes manager mode.

Changed:
`serviceAccountName` lookup from `.Values.serviceAccount.name` to `.Values.cluster.managerServiceAccount.name`. This aligns with the existing chart defaults and with `service-account.yaml.`

### Why?
When `cluster.manager=kubernetes` is set, the template referenced `.Values.serviceAccount.name`, but `values.yaml` defines `cluster.managerServiceAccount.name` instead. That caused: `nil pointer evaluating interface {}.name` and blocked chart rendering/install unless users added undocumented values.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Validation performed with Helm rendering for Kubernetes manager mode:

No nil-pointer error
`clusterManager: kubernetes rendered`
`serviceAccountName` rendered correctly from default fullname when not explicitly set

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ x] Implementation tested