### PR TITLE
fix: replace curl telnet with bash /dev/tcp for Zookeeper connectivit…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [PR #657](https://github.com/konpyutaika/nifikop/pull/657) - **[Operator]** Upgrade golang to 1.26.2.
 
 ### Fixed Bugs
+- [PR #655](https://github.com/konpyutaika/nifikop/pull/655) - **[Operator/NifiCluster]** Update Zookeeper connectivity validation.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 - [PR #657](https://github.com/konpyutaika/nifikop/pull/657) - **[Operator]** Upgrade golang to 1.26.2.
 
 ### Fixed Bugs
-- [PR #655](https://github.com/konpyutaika/nifikop/pull/655) - **[Operator/NifiCluster]** Update Zookeeper connectivity validation.
 
 ### Deprecated
 
@@ -938,3 +937,4 @@
 ### Removed
 
 ### Fixed Bugs
+- [PR #655](https://github.com/konpyutaika/nifikop/pull/655) - **[Operator/NifiCluster]** Update Zookeeper connectivity validation.

--- a/pkg/resources/nifi/pod.go
+++ b/pkg/resources/nifi/pod.go
@@ -527,8 +527,8 @@ do
 
 		echo "Checking Zookeeper Host: [${zk_host_port[0]}] Port: [${zk_host_port[1]}]"
 		set +e
-		curl --telnet-option 'BOGUS=1' --connect-timeout 2 -s telnet://${zk_host_port[0]}:${zk_host_port[1]} < /dev/null
-		if [ $? -eq 48 ]; then
+		timeout 2 bash -c "</dev/tcp/${zk_host_port[0]}/${zk_host_port[1]}" 2>/dev/null
+		if [ $? -eq 0 ]; then
 			echo "Connected to ${zk_host_port}"
 			connected=1
 		fi


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets |
| License         | Apache 2.0


### What's in this PR?

Replaces the `curl --telnet-option` trick used to probe Zookeeper host reachability with bash's built-in `/dev/tcp` redirect. The old approach used `curl` with a deliberately invalid telnet option (`BOGUS=1`) and checked for exit code 48 (`CURLE_UNKNOWN_TELNET_OPTION`) as a proxy for "connected successfully." The new approach uses `timeout 2 bash -c "</dev/tcp/$host/$port"` and checks for exit code 0.

### Why?

Some hardened container images compile `curl` without telnet support. When telnet is unsupported, `curl` does not return exit code 48 — it either errors differently or hangs, causing the Zookeeper readiness loop to spin indefinitely and block pod startup.

The `bash /dev/tcp` approach requires no external tools and works in any environment where bash is available (which is already a requirement for this init script).

### Checklist

- [x] Implementation tested
- [ ] User guide and development docs updated (if needed)
- [x] Append changelog with changes