### PR TITLE
fix: correct service account name in role binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed Bugs
 
 - [PR #662](https://github.com/konpyutaika/nifikop/pull/662) - **[Operator/Helm Chart/NifiCluster]** Fix Kubernetes manager mode by adding operator leader-election RBAC, propagating the manager `serviceAccountName` to explicit `nodeConfigGroups`, and publishing not-ready headless addresses only in Kubernetes mode.
+- [PR #667](https://github.com/konpyutaika/nifikop/pull/667) - **[Helm Chart/NifiCluster]** Fix `RoleBinding` subject name to correctly reference the `ServiceAccount` created by the chart, using `managerServiceAccount.name` when overridden.
 
 ### Deprecated
 

--- a/helm/nifi-cluster/templates/role-binding.yaml
+++ b/helm/nifi-cluster/templates/role-binding.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ include "nifi-cluster.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "nifi-cluster.fullname" . }}
+    name: {{ include "nifi-cluster.managerServiceAccountName" . }}
 roleRef:
   kind: Role
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
- Use `managerServiceAccountName` helper instead of `fullname` for subject
- Add missing newline at end of file

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Fix the RoleBinding subject name in the Helm chart to use nifi-cluster.managerServiceAccountName instead of nifi-cluster.fullname, so it correctly references the actual ServiceAccount created by the chart (which already used managerServiceAccountName). 

### Why?
The RoleBinding was referencing the wrong ServiceAccount name when Values.cluster.managerServiceAccount.name was overridden. This caused the binding to point to a non-existent service account, breaking RBAC in kubernetes manager mode.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Append changelog with changes