### PR TITLE
fix: NifiCluster Helm chart service account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### Fixed Bugs
 
-- [PR #662](https://github.com/konpyutaika/nifikop/pull/662) - **[Operator/Helm Chart/NifiCluster]** Fix Kubernetes manager mode by adding operator leader-election RBAC, propagating the manager `serviceAccountName` to explicit `nodeConfigGroups`, and publishing not-ready headless addresses only in Kubernetes mode.
+- [PR #662](https://github.com/konpyutaika/nifikop/pull/662) - **[Helm Chart]** Fix Kubernetes manager mode by adding operator leader-election RBAC, propagating the manager `serviceAccountName` to explicit `nodeConfigGroups`, and publishing not-ready headless addresses only in Kubernetes mode.
+- [PR #680](https://github.com/konpyutaika/nifikop/pull/680) - **[Helm Chart]** Rollback part of change on NiFiCluster introduced by [PR #662](https://github.com/konpyutaika/nifikop/pull/662).
 
 ### Deprecated
 

--- a/helm/nifi-cluster/templates/nifi-cluster.yaml
+++ b/helm/nifi-cluster/templates/nifi-cluster.yaml
@@ -182,18 +182,9 @@ spec:
   {{- if empty .Values.cluster.nodeConfigGroups }}
     {{- if eq .Values.cluster.manager "kubernetes" }}
     default-group:
-      serviceAccountName: {{ $managerServiceAccountName }}
+      serviceAccountName: {{ tpl (default (include "nifi-cluster.fullname" .) .Values.cluster.managerServiceAccount.name) . }}
     {{- end }}
-  {{- else }}
-  {{- range $groupName, $groupConfig := .Values.cluster.nodeConfigGroups }}
-    {{- $renderedGroup := deepCopy $groupConfig }}
-    {{- if and (eq $.Values.cluster.manager "kubernetes") (not $renderedGroup.serviceAccountName) }}
-    {{- $_ := set $renderedGroup "serviceAccountName" $managerServiceAccountName }}
-    {{- end }}
-    {{ $groupName }}:
-{{ toYaml $renderedGroup | nindent 6 }}
-  {{- end }}
-  {{- end }}
+    {{- tpl (toYaml .Values.cluster.nodeConfigGroups) . | nindent 4 }}
   nodes:
   {{- toYaml .Values.cluster.nodes | nindent 4 }}
   propagateLabels: {{ .Values.cluster.propagateLabels }}

--- a/helm/nifi-cluster/templates/role-binding.yaml
+++ b/helm/nifi-cluster/templates/role-binding.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ include "nifi-cluster.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "nifi-cluster.fullname" . }}
+    name: {{ tpl (default (include "nifi-cluster.fullname" .) .Values.cluster.managerServiceAccount.name) . }}
 roleRef:
   kind: Role
   apiGroup: rbac.authorization.k8s.io

--- a/helm/nifi-cluster/templates/service-account.yaml
+++ b/helm/nifi-cluster/templates/service-account.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "nifi-cluster.managerServiceAccountName" . }}
+  name: {{ tpl (default (include "nifi-cluster.fullname" .) .Values.cluster.managerServiceAccount.name) . }}
   namespace: {{ .Release.Namespace }}
   annotations: 
 {{ toYaml .Values.cluster.managerServiceAccount.annotations | indent 4 }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Put back how was working the NifiCluster helm chart for Service Account.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
https://github.com/konpyutaika/nifikop/pull/662 introduced a change on how the service account for nifi cluster was handled but it's not coherent and functional.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
