### PR TITLE
Add printcolumns to NiFiCluster resource

### DIFF
--- a/api/v1/nificluster_types.go
+++ b/api/v1/nificluster_types.go
@@ -704,6 +704,9 @@ type PrometheusReportingTaskStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="Cluster state",type="string",JSONPath=".status.state",description="The current operational state of the NiFi cluster"
+// +kubebuilder:printcolumn:name="Upgrade Errors",type="integer",JSONPath=".status.rollingUpgradeStatus.errorCount",description="Number of errors encountered during rolling upgrades"
+// +kubebuilder:printcolumn:name="Last Upgrade",type="string",JSONPath=".status.rollingUpgradeStatus.lastSuccess",description="Timestamp of the last successful rolling upgrade"
 
 // NifiCluster is the Schema for the nificlusters API.
 type NifiCluster struct {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Adds printcolumns to NiFiCluster resource.

### Why?
To make it easier to monitor cluster's state:
```
~ kubectl get nificluster
NAME    CLUSTER STATE    UPGRADE ERRORS   LAST UPGRADE
test1   ClusterRunning   0                Thu, 16 Jul 2026 11:30:39 GMT
test2   ClusterRunning   0                Fri, 17 Jul 2026 09:54:01 GMT
```

### Checklist

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)
- [ ] Append changelog with changes
