### PR TITLE
feat(nificluster): expose hostUsers on NodeConfig for NiFi pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - [PR #692](https://github.com/konpyutaika/nifikop/pull/692) - **[Operator/NifiCluster]** Add printcolumns to NiFiCluster resource.
+- [PR #723](https://github.com/konpyutaika/nifikop/pull/723) - **[Operator/NifiCluster]** Add `hostUsers` to `NodeConfig` so NiFi pods can run in a Linux user namespace (`hostUsers: false`), as required by OpenShift SCCs with `userNamespaceLevel: RequirePodLevel` (e.g. `restricted-v3`).
 
 ### Changed
 

--- a/api/v1/nificluster_types.go
+++ b/api/v1/nificluster_types.go
@@ -340,6 +340,11 @@ type NodeConfig struct {
 	// FSGroup define the id of the group for each volumes in Nifi image
 	// +kubebuilder:validation:Minimum=1
 	FSGroup *int64 `json:"fsGroup,omitempty"`
+	// hostUsers controls whether the node pods run in the host user namespace (Kubernetes default when unset).
+	// Set to false to run the pods in a dedicated Linux user namespace, which is required by OpenShift SCCs
+	// with userNamespaceLevel: RequirePodLevel (e.g. restricted-v3).
+	// https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/
+	HostUsers *bool `json:"hostUsers,omitempty"`
 	// Set this to true if the instance is a node in a cluster.
 	// https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#basic-cluster-setup
 	IsNode *bool `json:"isNode,omitempty"`

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1220,6 +1220,11 @@ func (in *NodeConfig) DeepCopyInto(out *NodeConfig) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.HostUsers != nil {
+		in, out := &in.HostUsers, &out.HostUsers
+		*out = new(bool)
+		**out = **in
+	}
 	if in.IsNode != nil {
 		in, out := &in.IsNode, &out.IsNode
 		*out = new(bool)

--- a/config/crd/bases/nifi.konpyutaika.com_nificlusters.yaml
+++ b/config/crd/bases/nifi.konpyutaika.com_nificlusters.yaml
@@ -1765,6 +1765,8 @@ spec:
                         - ip
                         type: object
                       type: array
+                    hostUsers:
+                      type: boolean
                     image:
                       type: string
                     imagePullPolicy:
@@ -3321,6 +3323,8 @@ spec:
                             - ip
                             type: object
                           type: array
+                        hostUsers:
+                          type: boolean
                         image:
                           type: string
                         imagePullPolicy:

--- a/config/crd/bases/nifi.konpyutaika.com_nifinodegroupautoscalers.yaml
+++ b/config/crd/bases/nifi.konpyutaika.com_nifinodegroupautoscalers.yaml
@@ -855,6 +855,8 @@ spec:
                       - ip
                       type: object
                     type: array
+                  hostUsers:
+                    type: boolean
                   image:
                     type: string
                   imagePullPolicy:

--- a/helm/nifikop/crds/nifi.konpyutaika.com_nificlusters.yaml
+++ b/helm/nifikop/crds/nifi.konpyutaika.com_nificlusters.yaml
@@ -1765,6 +1765,8 @@ spec:
                         - ip
                         type: object
                       type: array
+                    hostUsers:
+                      type: boolean
                     image:
                       type: string
                     imagePullPolicy:
@@ -3321,6 +3323,8 @@ spec:
                             - ip
                             type: object
                           type: array
+                        hostUsers:
+                          type: boolean
                         image:
                           type: string
                         imagePullPolicy:

--- a/helm/nifikop/crds/nifi.konpyutaika.com_nifinodegroupautoscalers.yaml
+++ b/helm/nifikop/crds/nifi.konpyutaika.com_nifinodegroupautoscalers.yaml
@@ -855,6 +855,8 @@ spec:
                       - ip
                       type: object
                     type: array
+                  hostUsers:
+                    type: boolean
                   image:
                     type: string
                   imagePullPolicy:

--- a/pkg/resources/nifi/pod.go
+++ b/pkg/resources/nifi/pod.go
@@ -182,6 +182,7 @@ func (r *Reconciler) pod(node v1.Node, nodeConfig *v1.NodeConfig, pvcs []corev1.
 				FSGroup:        nodeConfig.GetFSGroup(),
 				SeccompProfile: seccompProfile,
 			},
+			HostUsers:                     nodeConfig.HostUsers,
 			TerminationGracePeriodSeconds: terminationGracePeriodSeconds,
 			InitContainers:                podInitContainers,
 			Affinity:                      aff,

--- a/pkg/resources/nifi/pod_test.go
+++ b/pkg/resources/nifi/pod_test.go
@@ -1,0 +1,67 @@
+package nifi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/konpyutaika/nifikop/api/v1"
+	"github.com/konpyutaika/nifikop/pkg/resources"
+)
+
+func newPodTestReconciler() *Reconciler {
+	return &Reconciler{
+		Reconciler: resources.Reconciler{
+			NifiCluster: &v1.NifiCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster",
+					Namespace: "namespace",
+				},
+				Spec: v1.NifiClusterSpec{
+					ListenersConfig: &v1.ListenersConfig{
+						InternalListeners: []v1.InternalListenerConfig{
+							{Type: v1.HttpListenerType, Name: "http", ContainerPort: 8080},
+							{Type: v1.ClusterListenerType, Name: "cluster", ContainerPort: 6007},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestPodHostUsers(t *testing.T) {
+	falseVal := false
+	trueVal := true
+
+	tests := []struct {
+		name      string
+		hostUsers *bool
+	}{
+		{name: "unset leaves hostUsers absent", hostUsers: nil},
+		{name: "false is propagated", hostUsers: &falseVal},
+		{name: "true is propagated", hostUsers: &trueVal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newPodTestReconciler()
+			nodeConfig := &v1.NodeConfig{HostUsers: tt.hostUsers}
+			node := v1.Node{Id: 0}
+
+			obj := r.pod(node, nodeConfig, []corev1.PersistentVolumeClaim{}, zap.Logger{})
+			pod, ok := obj.(*corev1.Pod)
+			assert.True(t, ok, "pod() should return a *corev1.Pod")
+
+			if tt.hostUsers == nil {
+				assert.Nil(t, pod.Spec.HostUsers)
+			} else {
+				assert.NotNil(t, pod.Spec.HostUsers)
+				assert.Equal(t, *tt.hostUsers, *pod.Spec.HostUsers)
+			}
+		})
+	}
+}

--- a/site/docs/5_references/1_nifi_cluster/3_node_config.md
+++ b/site/docs/5_references/1_nifi_cluster/3_node_config.md
@@ -14,6 +14,9 @@ NodeConfig defines the node configuration
       #RunAsUser define the id of the user to run in the Nifi image
       # +kubebuilder:validation:Minimum=1
       runAsUser: 1000
+      # hostUsers controls whether the node pods run in the host user namespace.
+      # Set to false to run the pods in a dedicated Linux user namespace (e.g. for the OpenShift restricted-v3 SCC).
+      # hostUsers: false
       # Set this to true if the instance is a node in a cluster.
       # https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#basic-cluster-setup
       isNode: true
@@ -81,6 +84,7 @@ NodeConfig defines the node configuration
 | provenanceStorage     | string                                                                                       |provenanceStorage allow to specify the maximum amount of data provenance information to store at a time: [write-ahead-provenance-repository-properties](https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#write-ahead-provenance-repository-properties)|No|"8 GB"|
 | runAsUser             | int64                                                                                        |define the id of the user to run in the Nifi image|No|1000|
 | fsGroup               | int64                                                                                        |define the id of the group for each volumes in Nifi image|No|1000|
+| hostUsers             | boolean                                                                                      |controls whether the node pods run in the host user namespace. Set to `false` to run the pods in a dedicated [Linux user namespace](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/), as required by OpenShift SCCs with `userNamespaceLevel: RequirePodLevel` (e.g. `restricted-v3`).|No|unset (Kubernetes default)|
 | isNode                | boolean                                                                                      |Set this to true if the instance is a node in a cluster: [basic-cluster-setup](https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#basic-cluster-setup)|No|true|
 | image                 | string                                                                                       | Docker image used by the operator to create the node associated. [Nifi docker registry](https://hub.docker.com/r/apache/nifi/)|No|""|
 | imagePullPolicy       | [PullPolicy](https://godoc.org/k8s.io/api/core/v1#PullPolicy)                                | define the pull policy for NiFi cluster docker image.|No|""|


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #722
| License         | Apache 2.0


### What's in this PR?

First attempt at #722. Adds an optional `hostUsers` field to `NodeConfig` (v1) and passes it through to the NiFi pod spec, alongside the existing `runAsUser` / `fsGroup` fields.

```yaml
nodeConfigGroups:
  default-group:
    runAsUser: 1000
    hostUsers: false
```

Setting `hostUsers: false` runs the pods in a Linux user namespace, which OpenShift SCCs with `userNamespaceLevel: RequirePodLevel` (e.g. `restricted-v3`, OCP 4.20+) require. When unset the field is omitted from the pod, so existing clusters are unaffected.

### Additional context

- Unit test added for the pod spec (unset / false / true).
- CRDs and deepcopy regenerated with `make generate manifests`; `go test ./api/... ./pkg/...` passes.
- No Helm chart change needed: `nodeConfigGroups` is passed through verbatim.

### Checklist

- [x] Implementation tested
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes

