### PR TITLE
feat(helm): support cluster-wide watch and fix RBAC for empty namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - [PR #692](https://github.com/konpyutaika/nifikop/pull/692) - **[Operator/NifiCluster]** Add printcolumns to NiFiCluster resource.
+- [PR #725](https://github.com/konpyutaika/nifikop/pull/725) - **[Helm Chart]** Add `watchAnyNamespace` to run the operator cluster-wide, and `createClusterScopedResources` to control cluster-scoped RBAC. Namespaced permissions are now a single `ClusterRole` bound per watched namespace or cluster-wide.
 
 ### Changed
 
@@ -15,6 +16,7 @@
 - [PR #680](https://github.com/konpyutaika/nifikop/pull/680) - **[Helm Chart]** Rollback part of change on NiFiCluster introduced by [PR #662](https://github.com/konpyutaika/nifikop/pull/662).
 - [PR #668](https://github.com/konpyutaika/nifikop/pull/668) - **[Helm Chart]** Add configurable operator webhook TLS support with backward-compatible cert-manager and existing-secret flows.
 - [PR #664](https://github.com/konpyutaika/nifikop/pull/664) - **[Helm Chart/OpenShift]** Add explicit OpenShift SCC support for the operator and NiFi workloads, including support for existing SCCs and corrected SCC RBAC handling.
+- [PR #725](https://github.com/konpyutaika/nifikop/pull/725) - **[Helm Chart]** Fix RBAC when `namespaces` is empty: the chart rendered no `Role`/`RoleBinding` at all while the operator watched the release namespace. The release namespace is now the default watched namespace. Grant `namespaces`/`nodes` read access and move `clusterissuers` to a `ClusterRole`, since a namespaced `Role` cannot grant cluster-scoped resources.
 
 ### Deprecated
 

--- a/helm/nifikop/README.md
+++ b/helm/nifikop/README.md
@@ -37,7 +37,9 @@ The following tables lists the configurable parameters of the NiFi Operator Helm
 | `logLevel`                       | Log level to output                                                                                                                                                                  | `Info`                   |
 | `logEncoding`                    | Log encoding to use. Either `json` or `console`                                                                                                                                      | `json`                   |
 | `certManager.clusterScoped`      | If true setup cluster scoped resources                                                                                                                                               | `false`                  |
-| `namespaces`                     | List of namespaces where Operator watches for custom resources. Make sure the operator ServiceAccount is granted `get` permissions on this `Node` resource when using limited RBACs. | `""` i.e. all namespaces |
+| `namespaces`                     | List of namespaces where the operator watches for custom resources. Empty means the release namespace only. Ignored when `watchAnyNamespace` is `true`.                             | `[]`                     |
+| `watchAnyNamespace`              | Watch every namespace in the cluster. Leaves `WATCH_NAMESPACE` unset and binds the operator RBAC cluster-wide. Requires `createClusterScopedResources=true`.                         | `false`                  |
+| `createClusterScopedResources`   | Create `ClusterRole`/`ClusterRoleBinding` resources. When `false`, only namespaced `Role`/`RoleBinding` are rendered in the watched namespaces (incompatible with `watchAnyNamespace` and `certManager.clusterScoped`). | `true`                   |
 | `nodeSelector`                   | Node selector configuration for operator pod                                                                                                                                         | `{}`                     |
 | `affinity`                       | Node affinity configuration for operator pod                                                                                                                                         | `{}`                     |
 | `tolerations`                    | Toleration configuration for operator pod                                                                                                                                            | `{}`                     |
@@ -106,6 +108,28 @@ $ helm install nifikop konpyutaika-incubator/nifikop --replace --set image.tag=a
 ```
 
 > the `--replace` flag allow you to reuses a charts release name
+
+### Watched namespaces and RBAC
+
+By default the operator watches the namespace it is installed in. To watch a fixed set of namespaces:
+
+```console
+$ helm install nifikop konpyutaika-incubator/nifikop --set namespaces={"nifi","data"}
+```
+
+To watch every namespace in the cluster:
+
+```console
+$ helm install nifikop konpyutaika-incubator/nifikop --set watchAnyNamespace=true
+```
+
+Namespaced permissions are defined once as a `ClusterRole` and bound with a `RoleBinding` in each watched
+namespace, or with a single `ClusterRoleBinding` when `watchAnyNamespace=true`. A second `ClusterRole` grants
+read access to `namespaces` and `nodes` (and `clusterissuers` when `certManager.clusterScoped=true`), which the
+operator needs regardless of the watched namespaces.
+
+If cluster-scoped RBAC is not permitted in your cluster, set `createClusterScopedResources=false` to render a
+`Role`/`RoleBinding` pair in each watched namespace instead. This mode cannot watch all namespaces.
 
 ### OpenShift
 

--- a/helm/nifikop/templates/_functions.tpl
+++ b/helm/nifikop/templates/_functions.tpl
@@ -135,3 +135,204 @@ Return the appropriate apiVersion value to use for the capi-operator managed k8s
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Name of the ServiceAccount the operator runs as.
+*/}}
+{{- define "nifikop.serviceAccountName" -}}
+{{- if and .Values.serviceAccount .Values.serviceAccount.name -}}
+{{- .Values.serviceAccount.name -}}
+{{- else -}}
+{{- template "nifikop.name" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Namespaces the operator watches when not cluster-wide, as a YAML list.
+Defaults to the release namespace. Consume with `| fromYamlArray`.
+*/}}
+{{- define "nifikop.watchNamespaces" -}}
+{{- if .Values.namespaces -}}
+{{- toYaml .Values.namespaces -}}
+{{- else -}}
+{{- list .Release.Namespace | toYaml -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Reject value combinations that cannot produce working RBAC.
+*/}}
+{{- define "nifikop.rbac.validate" -}}
+{{- if and .Values.watchAnyNamespace (not .Values.createClusterScopedResources) -}}
+{{- fail "watchAnyNamespace=true requires createClusterScopedResources=true (cluster-wide watch needs a ClusterRoleBinding)" -}}
+{{- end -}}
+{{- if and .Values.watchAnyNamespace .Values.namespaces -}}
+{{- fail "namespaces must be empty when watchAnyNamespace=true" -}}
+{{- end -}}
+{{- if and .Values.certManager.clusterScoped (not .Values.createClusterScopedResources) -}}
+{{- fail "certManager.clusterScoped=true requires createClusterScopedResources=true (ClusterIssuer access cannot be granted by a namespaced Role)" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Permissions on namespaced resources, shared by the ClusterRole and per-namespace Role variants.
+*/}}
+{{- define "nifikop.rbac.namespacedRules" -}}
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - nifikop
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - get
+- apiGroups:
+  - nifi.konpyutaika.com
+  resources:
+  - "nifiusers"
+  - "nifiusergroups"
+  - "nificlusters"
+  - "nifidataflows"
+  - "nifiregistryclients"
+  - "nifiparametercontexts"
+  - "nifinodegroupautoscalers"
+  - "nificonnections"
+  - "nifiresources"
+  - "nifiusers/finalizers"
+  - "nificlusters/finalizers"
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - deletecollection
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - issuers
+  - certificates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - nifi.konpyutaika.com
+  resources:
+  - nifiusers/status
+  - nifiusergroups/status
+  - nificlusters/status
+  - nifidataflows/status
+  - nifiregistryclients/status
+  - nifiparametercontexts/status
+  - nifinodegroupautoscalers/status
+  - nificonnections/status
+  - nifiresources/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+{{- end -}}

--- a/helm/nifikop/templates/cluster_role.yaml
+++ b/helm/nifikop/templates/cluster_role.yaml
@@ -1,0 +1,64 @@
+{{- if and .Values.rbacEnable .Values.createClusterScopedResources }}
+{{- /*
+Permissions on cluster-scoped resources (namespaces, nodes, optionally ClusterIssuers).
+These can only be granted through a ClusterRole, regardless of which namespaces are watched.
+*/}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "nifikop.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    {{- include "userdefined.labels" . }}
+  annotations:
+    {{- include "userdefined.annotations" . }}
+  name: {{ template "nifikop.fullname" . }}-global
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+{{- if .Values.certManager.clusterScoped }}
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - clusterissuers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+{{- end }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app: {{ template "nifikop.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    {{- include "userdefined.labels" . }}
+  annotations:
+    {{- include "userdefined.annotations" . }}
+  name: {{ template "nifikop.fullname" . }}-global
+subjects:
+- kind: ServiceAccount
+  name: {{ template "nifikop.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "nifikop.fullname" . }}-global
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/helm/nifikop/templates/deployment.yaml
+++ b/helm/nifikop/templates/deployment.yaml
@@ -106,6 +106,8 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- end }}
           env:
+            {{- /* Leaving WATCH_NAMESPACE unset makes the operator watch all namespaces. */}}
+            {{- if not .Values.watchAnyNamespace }}
             - name: WATCH_NAMESPACE
               {{- if .Values.namespaces }}
               value: {{ join "," .Values.namespaces }}
@@ -114,6 +116,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
               {{- end }}
+            {{- end }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/helm/nifikop/templates/role.yaml
+++ b/helm/nifikop/templates/role.yaml
@@ -1,180 +1,47 @@
 {{- if .Values.rbacEnable }}
-{{- range  $namespace := $.Values.namespaces }}
-{{- $_ := set $ "vals" $.Values }}
+{{- include "nifikop.rbac.validate" . }}
+{{- if .Values.createClusterScopedResources }}
+{{- /*
+Namespaced permissions are defined once as a ClusterRole and bound per watched
+namespace (RoleBinding) or cluster-wide (ClusterRoleBinding), see role_binding.yaml.
+*/}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "nifikop.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    {{- include "userdefined.labels" . }}
+  annotations:
+    {{- include "userdefined.annotations" . }}
+  name: {{ template "nifikop.fullname" . }}-namespaced
+rules:
+{{ include "nifikop.rbac.namespacedRules" . }}
+{{- else }}
+{{- /*
+Without cluster-scoped resources, fall back to one Role per watched namespace.
+*/}}
+{{- $namespaces := include "nifikop.watchNamespaces" . | fromYamlArray }}
+{{- range $namespace := $namespaces }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app: {{ template "nifikop.name" $_ }}
+    app: {{ template "nifikop.name" $ }}
     chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
     heritage: {{ $.Release.Service }}
     release: {{ $.Release.Name }}
-    {{- include "userdefined.labels" $_ }}
+    {{- include "userdefined.labels" $ }}
   annotations:
-    {{- include "userdefined.annotations" $_ }}
-  name: {{ template "nifikop.name" $_ }}
-  namespace: {{$namespace}}
+    {{- include "userdefined.annotations" $ }}
+  name: {{ template "nifikop.name" $ }}
+  namespace: {{ $namespace }}
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
-  - create
-- apiGroups:
-  - apps
-  resourceNames:
-  - nifikop
-  resources:
-  - deployments/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  - deployments
-  verbs:
-  - get
-- apiGroups:
-  - nifi.konpyutaika.com
-  resources:
-  - "nifiusers"
-  - "nifiusergroups"
-  - "nificlusters"
-  - "nifidataflows"
-  - "nifiregistryclients"
-  - "nifiparametercontexts"
-  - "nifinodegroupautoscalers"
-  - "nificonnections"
-  - "nifiresources"
-  - "nifiusers/finalizers"
-  - "nificlusters/finalizers"
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-  - deletecollection
-- apiGroups:
-  - autoscaling
-  resources:
-  - horizontalpodautoscalers
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cert-manager.io
-  resources:
-  - issuers
-  {{-  if $.Values.certManager.clusterScoped }}
-  - clusterissuers
-  {{- end }}
-  - certificates
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - nifi.konpyutaika.com
-  resources:
-  - nifiusers/status
-  - nifiusergroups/status
-  - nificlusters/status
-  - nifidataflows/status
-  - nifiregistryclients/status
-  - nifiparametercontexts/status
-  - nifinodegroupautoscalers/status
-  - nificonnections/status
-  - nifiresources/status
-  verbs:
-  - get
-  - update
-  - patch
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-    - coordination.k8s.io
-  resources:
-    - leases
-  verbs:
-    - get
-    - list
-    - watch
-    - create
-    - update
-    - patch
-    - delete
-- apiGroups:
-    - ""
-  resources:
-    - events
-  verbs:
-    - create
-    - patch
----
-{{- end}}
-{{- end}}
+{{ include "nifikop.rbac.namespacedRules" $ }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/nifikop/templates/role_binding.yaml
+++ b/helm/nifikop/templates/role_binding.yaml
@@ -1,6 +1,36 @@
 {{- if .Values.rbacEnable }}
-{{- range  $namespace := $.Values.namespaces }}
-{{- $_ := set $ "vals" $.Values }}
+{{- if .Values.watchAnyNamespace }}
+{{- /*
+Cluster-wide: bind the namespaced ClusterRole to the operator across all namespaces.
+*/}}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app: {{ template "nifikop.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    {{- include "userdefined.labels" . }}
+  annotations:
+    {{- include "userdefined.annotations" . }}
+  name: {{ template "nifikop.fullname" . }}-namespaced
+subjects:
+- kind: ServiceAccount
+  name: {{ template "nifikop.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "nifikop.fullname" . }}-namespaced
+  apiGroup: rbac.authorization.k8s.io
+{{- else }}
+{{- /*
+Namespace list: one RoleBinding per watched namespace. It references the shared
+ClusterRole when cluster-scoped resources are allowed, otherwise the per-namespace Role.
+*/}}
+{{- $namespaces := include "nifikop.watchNamespaces" . | fromYamlArray }}
+{{- range $namespace := $namespaces }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -10,19 +40,24 @@ metadata:
     chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
     heritage: {{ $.Release.Service }}
     release: {{ $.Release.Name }}
-    {{- include "userdefined.labels" $_ }}
+    {{- include "userdefined.labels" $ }}
   annotations:
-    {{- include "userdefined.annotations" $_ }}
+    {{- include "userdefined.annotations" $ }}
   name: {{ template "nifikop.name" $ }}
   namespace: {{ $namespace }}
 subjects:
 - kind: ServiceAccount
-  name: {{ if and $.Values.serviceAccount $.Values.serviceAccount.name }}{{ $.Values.serviceAccount.name }}{{ else }}{{ template "nifikop.name" $ }}{{ end }}
+  name: {{ template "nifikop.serviceAccountName" $ }}
   namespace: {{ $.Release.Namespace }}
 roleRef:
+  {{- if $.Values.createClusterScopedResources }}
+  kind: ClusterRole
+  name: {{ template "nifikop.fullname" $ }}-namespaced
+  {{- else }}
   kind: Role
   name: {{ template "nifikop.name" $ }}
+  {{- end }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
 {{- end }}
----
+{{- end }}

--- a/helm/nifikop/values.yaml
+++ b/helm/nifikop/values.yaml
@@ -10,8 +10,13 @@ image:
 vaultAddress: ""
 # vaultSecret containing a `ca.crt` key with the Vault CA Certificate
 vaultSecret: ""
-# set of namespaces where the operator watches resources
+## Namespaces where the operator watches for custom resources.
+## An empty list means the release namespace only. Ignored when watchAnyNamespace is true.
 namespaces: []
+
+## If true, watch every namespace in the cluster. WATCH_NAMESPACE is left unset and the
+## operator RBAC is bound cluster-wide. Requires createClusterScopedResources=true.
+watchAnyNamespace: false
 
 # Optional labels to add to all deployed resources
 labels: {}
@@ -65,6 +70,13 @@ createCustomResource: true
 ## If true, create & use RBAC resources
 ##
 rbacEnable: true
+
+## If true, create cluster-scoped RBAC (ClusterRole/ClusterRoleBinding). Namespaced permissions
+## are defined once as a ClusterRole and bound per watched namespace, and the operator gets
+## get/list/watch on namespaces and nodes (plus ClusterIssuers when certManager.clusterScoped).
+## Set to false to render only namespaced Roles/RoleBindings in the watched namespaces; this
+## is incompatible with watchAnyNamespace and certManager.clusterScoped.
+createClusterScopedResources: true
 
 ## If true, create serviceAccount
 ##

--- a/site/docs/2_deploy_nifikop/2_customizable_install_with_helm.md
+++ b/site/docs/2_deploy_nifikop/2_customizable_install_with_helm.md
@@ -50,7 +50,9 @@ The following tables lists the configurable parameters of the NiFi Operator Helm
 | `logLevel`                       | Log level to output                                                                                                                                                                  | `Info`                   |
 | `logEncoding`                    | Log encoding to use. Either `json` or `console`                                                                                                                                      | `json`                   |
 | `certManager.clusterScoped`      | If true setup cluster scoped resources                                                                                                                                               | `false`                  |
-| `namespaces`                     | List of namespaces where Operator watches for custom resources. Make sure the operator ServiceAccount is granted `get` permissions on this `Node` resource when using limited RBACs. | `""` i.e. all namespaces |
+| `namespaces`                     | List of namespaces where the operator watches for custom resources. Empty means the release namespace only. Ignored when `watchAnyNamespace` is `true`.                             | `[]`                     |
+| `watchAnyNamespace`              | Watch every namespace in the cluster. Leaves `WATCH_NAMESPACE` unset and binds the operator RBAC cluster-wide. Requires `createClusterScopedResources=true`.                         | `false`                  |
+| `createClusterScopedResources`   | Create `ClusterRole`/`ClusterRoleBinding` resources. When `false`, only namespaced `Role`/`RoleBinding` are rendered in the watched namespaces (incompatible with `watchAnyNamespace` and `certManager.clusterScoped`). | `true`                   |
 | `nodeSelector`                   | Node selector configuration for operator pod                                                                                                                                         | `{}`                     |
 | `affinity`                       | Node affinity configuration for operator pod                                                                                                                                         | `{}`                     |
 | `tolerations`                    | Toleration configuration for operator pod                                                                                                                                            | `{}`                     |
@@ -156,6 +158,28 @@ helm install nifikop konpyutaika/nifikop --set namespaces={"nifikop"}
 </Tabs>
 
 > the `--replace` flag allow you to reuses a charts release name
+
+### Watched namespaces and RBAC
+
+By default the operator watches the namespace it is installed in. To watch a fixed set of namespaces:
+
+```console
+$ helm install nifikop konpyutaika/nifikop --set namespaces={"nifi","data"}
+```
+
+To watch every namespace in the cluster:
+
+```console
+$ helm install nifikop konpyutaika/nifikop --set watchAnyNamespace=true
+```
+
+Namespaced permissions are defined once as a `ClusterRole` and bound with a `RoleBinding` in each watched
+namespace, or with a single `ClusterRoleBinding` when `watchAnyNamespace=true`. A second `ClusterRole` grants
+read access to `namespaces` and `nodes` (and `clusterissuers` when `certManager.clusterScoped=true`), which the
+operator needs regardless of the watched namespaces.
+
+If cluster-scoped RBAC is not permitted in your cluster, set `createClusterScopedResources=false` to render a
+`Role`/`RoleBinding` pair in each watched namespace instead. This mode cannot watch all namespaces.
 
 ### Listing deployed charts
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #724
| License         | Apache 2.0


### What's in this PR?

Lets the Helm chart run the operator cluster-wide, and fixes the chart's RBAC when `namespaces` is left empty.

Two new values, following the pattern used by other popular charts such as Strimzi and ECK operatos:

- `watchAnyNamespace` (default `false`): when `true`, `WATCH_NAMESPACE` is left unset (the operator already treats that as "all namespaces") and the operator's namespaced permissions are bound with a single `ClusterRoleBinding`.
- `createClusterScopedResources` (default `true`): namespaced permissions are defined once as a `ClusterRole` and bound with a `RoleBinding` per watched namespace. A second small `ClusterRole` grants `get/list/watch` on `namespaces` and `nodes`, plus `clusterissuers` when `certManager.clusterScoped=true`. Set to `false` to get the previous per-namespace `Role`/`RoleBinding` rendering for clusters where cluster-scoped RBAC is not allowed.

```yaml
# cluster-wide
watchAnyNamespace: true

# or a fixed list (unchanged)
namespaces: [nifi, data]
```

Rendering per mode:

| Values | Namespaced rules | Binding | Cluster-scoped rules |
|---|---|---|---|
| default | `ClusterRole` | `RoleBinding` in release namespace | `ClusterRole` + `ClusterRoleBinding` |
| `namespaces=[a,b]` | `ClusterRole` | `RoleBinding` in `a` and `b` | same |
| `watchAnyNamespace=true` | `ClusterRole` | `ClusterRoleBinding` | same |
| `createClusterScopedResources=false` | `Role` per namespace | `RoleBinding` per namespace | none |

Invalid combinations fail at template time with a message (`watchAnyNamespace` without cluster-scoped resources, `watchAnyNamespace` together with `namespaces`, `certManager.clusterScoped` without cluster-scoped resources).

### Why?

- With the default `namespaces: []`, `role.yaml` and `role_binding.yaml` range over an empty list and render nothing, while the Deployment sets `WATCH_NAMESPACE` to the release namespace. A default install had no RBAC for the operator's own work. The release namespace is now the default watched namespace, so the default install gets a `RoleBinding` there.
- There was no way to leave `WATCH_NAMESPACE` unset from values, so cluster-wide mode was unreachable via Helm even though the operator and the kustomize manifests (`config/rbac/role.yaml` is a `ClusterRole`) support it.
- `NifiClusterReconciler.checkFinalizers` lists all `Namespaces` when no namespace list is configured, and the controller RBAC markers ask for `nodes`, `namespaces` and `clusterissuers`. A namespaced `Role` can never grant those. The chart previously put `clusterissuers` inside the `Role`, which is a no-op.

### Additional context

- The shared rules block is the previous `Role` rules verbatim (only `clusterissuers` moved to the cluster-scoped `ClusterRole`). Verified by diffing the rendered rules against the current chart.
- Cluster-scoped objects are named from the release (`<fullname>-namespaced`, `<fullname>-global`) so two operator releases on one cluster do not collide.
- Rendered every combination above with `helm template` and ran `helm lint`. No Go changes.
- Validated in-cluster (k8s 1.36, operator image `v1.17.0-release`) by switching a running install from `namespaces: [nifi]` to `watchAnyNamespace: true`: the old `Role`/`RoleBinding` were replaced by the `ClusterRole`s and bindings, `WATCH_NAMESPACE` was dropped, the existing `NifiCluster` stayed `ClusterRunning` with no NiFi pod restart, a `NifiParameterContext` created in a different namespace was reconciled, and no RBAC errors were logged. Switching back to the namespaced values restored the previous objects.
- Docs: `helm/nifikop/README.md` and `site/docs/2_deploy_nifikop/2_customizable_install_with_helm.md` gained a "Watched namespaces and RBAC" section; the misleading `""` i.e. all namespaces default in the parameter table is corrected.

### Checklist

- [x] Implementation tested
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
